### PR TITLE
Avoid ClassNotFoundException on Android (API level < 19)

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ListBlockParser.java
@@ -3,7 +3,6 @@ package org.commonmark.internal;
 import org.commonmark.node.*;
 import org.commonmark.parser.block.*;
 
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -84,11 +83,15 @@ public class ListBlockParser extends AbstractBlockParser {
      */
     private static boolean listsMatch(ListBlock a, ListBlock b) {
         if (a instanceof BulletList && b instanceof BulletList) {
-            return Objects.equals(((BulletList) a).getBulletMarker(), ((BulletList) b).getBulletMarker());
+            return equals(((BulletList) a).getBulletMarker(), ((BulletList) b).getBulletMarker());
         } else if (a instanceof OrderedList && b instanceof OrderedList) {
-            return Objects.equals(((OrderedList) a).getDelimiter(), ((OrderedList) b).getDelimiter());
+            return equals(((OrderedList) a).getDelimiter(), ((OrderedList) b).getDelimiter());
         }
         return false;
+    }
+
+    private static boolean equals(Object a, Object b) {
+        return (a == null) ? (b == null) : a.equals(b);
     }
 
     public static class Factory extends AbstractBlockParserFactory {

--- a/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Escaping.java
@@ -1,6 +1,6 @@
 package org.commonmark.internal.util;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,7 +78,7 @@ public class Escaping {
                     sb.append(input, 1, input.length());
                 }
             } else {
-                byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+                byte[] bytes = input.getBytes(Charset.forName("UTF-8"));
                 for (byte b : bytes) {
                     sb.append('%');
                     sb.append(HEX_DIGITS[(b >> 4) & 0xF]);

--- a/commonmark/src/main/java/org/commonmark/internal/util/Html5Entities.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Html5Entities.java
@@ -4,7 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -43,7 +43,8 @@ public class Html5Entities {
     private static Map<String, String> readEntities() {
         Map<String, String> entities = new HashMap<>();
         InputStream stream = Html5Entities.class.getResourceAsStream("entities.properties");
-        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+        Charset charset = Charset.forName("UTF-8");
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream, charset))) {
             String line;
             while ((line = bufferedReader.readLine()) != null) {
                 if (line.length() == 0) {


### PR DESCRIPTION
There was removed usage of following classes: `Objects` and `StandardCharset`. When support of Android below KitKat (API level 19) becomes [not-actual](http://developer.android.com/intl/ru/about/dashboards/index.html) these changes can be reverted.