### PR TITLE
Add support for asymmetric delimiter processors (api break, #17)

### DIFF
--- a/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
+++ b/commonmark-ext-gfm-strikethrough/src/main/java/org/commonmark/ext/gfm/strikethrough/internal/StrikethroughDelimiterProcessor.java
@@ -8,7 +8,12 @@ import org.commonmark.parser.DelimiterProcessor;
 public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
 
     @Override
-    public char getDelimiterChar() {
+    public char getOpeningDelimiterChar() {
+        return '~';
+    }
+
+    @Override
+    public char getClosingDelimiterChar() {
         return '~';
     }
 
@@ -50,5 +55,4 @@ public class StrikethroughDelimiterProcessor implements DelimiterProcessor {
 
         opener.insertAfter(strikethrough);
     }
-
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/AsteriskDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/AsteriskDelimiterProcessor.java
@@ -1,8 +1,8 @@
 package org.commonmark.internal.inline;
 
 public class AsteriskDelimiterProcessor extends EmphasisDelimiterProcessor {
-    @Override
-    public char getDelimiterChar() {
-        return '*';
+
+    public AsteriskDelimiterProcessor() {
+        super('*');
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/EmphasisDelimiterProcessor.java
@@ -8,6 +8,22 @@ import org.commonmark.parser.DelimiterProcessor;
 
 public abstract class EmphasisDelimiterProcessor implements DelimiterProcessor {
 
+    private final char delimiterChar;
+
+    protected EmphasisDelimiterProcessor(char delimiterChar) {
+        this.delimiterChar = delimiterChar;
+    }
+
+    @Override
+    public char getOpeningDelimiterChar() {
+        return delimiterChar;
+    }
+
+    @Override
+    public char getClosingDelimiterChar() {
+        return delimiterChar;
+    }
+
     @Override
     public int getMinDelimiterCount() {
         return 1;
@@ -26,7 +42,7 @@ public abstract class EmphasisDelimiterProcessor implements DelimiterProcessor {
 
     @Override
     public void process(Text opener, Text closer, int delimiterUse) {
-        String singleDelimiter = String.valueOf(getDelimiterChar());
+        String singleDelimiter = String.valueOf(getOpeningDelimiterChar());
         Node emphasis = delimiterUse == 1
                 ? new Emphasis(singleDelimiter)
                 : new StrongEmphasis(singleDelimiter + singleDelimiter);

--- a/commonmark/src/main/java/org/commonmark/internal/inline/UnderscoreDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/inline/UnderscoreDelimiterProcessor.java
@@ -1,8 +1,8 @@
 package org.commonmark.internal.inline;
 
 public class UnderscoreDelimiterProcessor extends EmphasisDelimiterProcessor {
-    @Override
-    public char getDelimiterChar() {
-        return '_';
+
+    public UnderscoreDelimiterProcessor() {
+        super('_');
     }
 }

--- a/commonmark/src/main/java/org/commonmark/parser/DelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/parser/DelimiterProcessor.java
@@ -10,9 +10,16 @@ import org.commonmark.node.Text;
 public interface DelimiterProcessor {
 
     /**
-     * @return the character that activates this, must not clash with any built-in special characters
+     * @return the character that marks the beginning of a delimited node, must not clash with any built-in special
+     * characters
      */
-    char getDelimiterChar();
+    char getOpeningDelimiterChar();
+
+    /**
+     * @return the character that marks the the ending of a delimited node, must not clash with any built-in special
+     * characters. Note that for a symmetric delimiter such as "*", this is the same as the opening.
+     */
+    char getClosingDelimiterChar();
 
     /**
      * Minimum number of delimiter characters that are needed to activate this. Must be at least 1.

--- a/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
@@ -1,0 +1,96 @@
+package org.commonmark.test;
+
+import org.commonmark.html.CustomHtmlRenderer;
+import org.commonmark.html.HtmlRenderer;
+import org.commonmark.html.HtmlWriter;
+import org.commonmark.node.CustomNode;
+import org.commonmark.node.Node;
+import org.commonmark.node.Text;
+import org.commonmark.node.Visitor;
+import org.commonmark.parser.DelimiterProcessor;
+import org.commonmark.parser.Parser;
+import org.junit.Test;
+
+import java.util.Locale;
+
+public class DelimiterProcessorTest extends RenderingTestCase {
+
+    private static final Parser PARSER = Parser.builder().customDelimiterProcessor(new AsymmetricDelimiterProcessor()).build();
+    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().customHtmlRenderer(new UpperCaseNodeRenderer()).build();
+
+    @Test
+    public void asymmetricDelimiter() {
+        assertRendering("{foo} bar", "<p>FOO bar</p>\n");
+        assertRendering("f{oo ba}r", "<p>fOO BAr</p>\n");
+        assertRendering("{{foo} bar", "<p>{FOO bar</p>\n");
+        assertRendering("{foo}} bar", "<p>FOO} bar</p>\n");
+        assertRendering("{{foo} bar}", "<p>FOO BAR</p>\n");
+        assertRendering("{foo bar", "<p>{foo bar</p>\n");
+        assertRendering("foo} bar", "<p>foo} bar</p>\n");
+        assertRendering("}foo} bar", "<p>}foo} bar</p>\n");
+        assertRendering("{foo{ bar", "<p>{foo{ bar</p>\n");
+        assertRendering("}foo{ bar", "<p>}foo{ bar</p>\n");
+    }
+
+    @Override
+    protected String render(String source) {
+        Node node = PARSER.parse(source);
+        return RENDERER.render(node);
+    }
+
+    private static class AsymmetricDelimiterProcessor implements DelimiterProcessor {
+
+        @Override
+        public char getOpeningDelimiterChar() {
+            return '{';
+        }
+
+        @Override
+        public char getClosingDelimiterChar() {
+            return '}';
+        }
+
+        @Override
+        public int getMinDelimiterCount() {
+            return 1;
+        }
+
+        @Override
+        public int getDelimiterUse(int openerCount, int closerCount) {
+            return 1;
+        }
+
+        @Override
+        public void process(Text opener, Text closer, int delimiterUse) {
+            UpperCaseNode content = new UpperCaseNode();
+            Node tmp = opener.getNext();
+            while (tmp != null && tmp != closer) {
+                Node next = tmp.getNext();
+                content.appendChild(tmp);
+                tmp = next;
+            }
+            opener.insertAfter(content);
+        }
+    }
+
+    private static class UpperCaseNode extends CustomNode {
+    }
+
+    private static class UpperCaseNodeRenderer implements CustomHtmlRenderer {
+        @Override
+        public boolean render(Node node, HtmlWriter htmlWriter, Visitor visitor) {
+            if (node instanceof UpperCaseNode) {
+                UpperCaseNode upperCaseNode = (UpperCaseNode) node;
+                for (Node child = upperCaseNode.getFirstChild(); child != null; child = child.getNext()) {
+                    if (child instanceof Text) {
+                        Text text = (Text) child;
+                        text.setLiteral(text.getLiteral().toUpperCase(Locale.ENGLISH));
+                    }
+                    child.accept(visitor);
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
DelimiterProcessor can now specify an opening delimiter char and a
different closing delimiter char for asymmetric delimiters.

An example would be `{` as an opening delimiter and `}` as a closing
delimiter in `{foo}`.