### PR TITLE
add InsExtension to SpecIntegrationTest #54

### DIFF
--- a/commonmark-integration-test/pom.xml
+++ b/commonmark-integration-test/pom.xml
@@ -22,6 +22,10 @@
         </dependency>
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>
+            <artifactId>commonmark-ext-ins</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.commonmark</groupId>
             <artifactId>commonmark-ext-gfm-strikethrough</artifactId>
         </dependency>
         <dependency>

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
@@ -2,6 +2,7 @@ package org.commonmark.integration;
 
 import org.commonmark.Extension;
 import org.commonmark.ext.autolink.AutolinkExtension;
+import org.commonmark.ext.ins.InsExtension;
 import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
 import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.ext.front.matter.YamlFrontMatterExtension;
@@ -20,6 +21,7 @@ public class SpecIntegrationTest extends SpecTestCase {
 
     private static final List<Extension> EXTENSIONS = Arrays.asList(
             AutolinkExtension.create(),
+            InsExtension.create(),
             StrikethroughExtension.create(),
             TablesExtension.create(),
             YamlFrontMatterExtension.create());

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
             </dependency>
             <dependency>
                 <groupId>com.atlassian.commonmark</groupId>
+                <artifactId>commonmark-ext-ins</artifactId>
+                <version>0.6.1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.atlassian.commonmark</groupId>
                 <artifactId>commonmark-ext-gfm-strikethrough</artifactId>
                 <version>0.6.1-SNAPSHOT</version>
             </dependency>


### PR DESCRIPTION
Oops. Forgot to add the new `ins` extension to the `commonmark-integration-test` module.