### PR TITLE
Add prefix/suffix to ids generated

### DIFF
--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/HeadingAnchorExtension.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/HeadingAnchorExtension.java
@@ -29,11 +29,26 @@ import org.commonmark.renderer.html.HtmlRenderer;
  */
 public class HeadingAnchorExtension implements HtmlRenderer.HtmlRendererExtension {
 
-    private HeadingAnchorExtension() {
+    private final String defaultId;
+    private final String idPrefix;
+    private final String idSuffix;
+
+    private HeadingAnchorExtension(String defaultId, String idPrefix, String idSuffix) {
+        this.defaultId = defaultId;
+        this.idPrefix = idPrefix;
+        this.idSuffix = idSuffix;
     }
 
     public static Extension create() {
-        return new HeadingAnchorExtension();
+        return create(builder());
+    }
+
+    public static Extension create(Builder builder) {
+        return new HeadingAnchorExtension(builder.defaultId, builder.idPrefix, builder.idSuffix);
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -41,8 +56,51 @@ public class HeadingAnchorExtension implements HtmlRenderer.HtmlRendererExtensio
         rendererBuilder.attributeProviderFactory(new AttributeProviderFactory() {
             @Override
             public AttributeProvider create(AttributeProviderContext context) {
-                return HeadingIdAttributeProvider.create();
+                return HeadingIdAttributeProvider.create(defaultId, idPrefix, idSuffix);
             }
         });
+    }
+
+    public static class Builder {
+        private String defaultId;
+        private String idPrefix;
+        private String idSuffix;
+
+        public Builder() {
+            defaultId = "id";
+            idPrefix = "";
+            idSuffix = "";
+        }
+
+        /**
+         * @param value Default value for the id to take if no generated id can be extracted. Default "id"
+         * @return {@code this}
+         */
+        public Builder defaultId(String value) {
+            this.defaultId = value;
+            return this;
+        }
+
+        /**
+         * @param value Set the value to be prepended to every id generated. Default ""
+         * @return {@code this}
+         */
+        public Builder idPrefix(String value) {
+            this.idPrefix = value;
+            return this;
+        }
+
+        /**
+         * @param value Set the value to be appended to every id generated. Default ""
+         * @return
+         */
+        public Builder idSuffix(String value) {
+            this.idSuffix = value;
+            return this;
+        }
+
+        public Extension build() {
+            return HeadingAnchorExtension.create(this);
+        }
     }
 }

--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/HeadingAnchorExtension.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/HeadingAnchorExtension.java
@@ -43,7 +43,7 @@ public class HeadingAnchorExtension implements HtmlRenderer.HtmlRendererExtensio
         return create(builder());
     }
 
-    public static Extension create(Builder builder) {
+    private static Extension create(Builder builder) {
         return new HeadingAnchorExtension(builder.defaultId, builder.idPrefix, builder.idSuffix);
     }
 

--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/IdGenerator.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/IdGenerator.java
@@ -13,10 +13,14 @@ import java.util.regex.Pattern;
 public class IdGenerator {
     private final Pattern allowedCharacters = Pattern.compile("[\\w\\-_]+", Pattern.UNICODE_CHARACTER_CLASS);
     private final Map<String, Integer> identityMap;
+    private final String prefix;
+    private final String suffix;
     private String defaultIdentifier;
 
     private IdGenerator(Builder builder) {
         this.defaultIdentifier = builder.defaultIdentifier;
+        this.prefix = builder.prefix;
+        this.suffix = builder.suffix;
         this.identityMap = new HashMap<>();
     }
 
@@ -67,11 +71,11 @@ public class IdGenerator {
 
         if (!identityMap.containsKey(normalizedIdentity)) {
             identityMap.put(normalizedIdentity, 1);
-            return normalizedIdentity;
+            return prefix + normalizedIdentity + suffix;
         } else {
             int currentCount = identityMap.get(normalizedIdentity);
             identityMap.put(normalizedIdentity, currentCount + 1);
-            return normalizedIdentity + "-" + currentCount;
+            return prefix + normalizedIdentity + "-" + currentCount + suffix;
         }
     }
 
@@ -95,6 +99,8 @@ public class IdGenerator {
 
     public static class Builder {
         private String defaultIdentifier = "id";
+        private String prefix = "";
+        private String suffix = "";
 
         public IdGenerator build() {
             return new IdGenerator(this);
@@ -105,6 +111,25 @@ public class IdGenerator {
          * @return {@code this}
          */
         public Builder defaultId(String defaultId) {
+            this.defaultIdentifier = defaultId;
+            return this;
+        }
+
+        /**
+         * @param prefix the text to place before the generated identity
+         * @return {@code this}
+         */
+        public Builder prefix(String prefix) {
+            this.prefix = prefix;
+            return this;
+        }
+
+        /**
+         * @param suffix the text to place after the generated identity
+         * @return {@code this}
+         */
+        public Builder suffix(String suffix) {
+            this.suffix = suffix;
             return this;
         }
     }

--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/internal/HeadingIdAttributeProvider.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/internal/HeadingIdAttributeProvider.java
@@ -12,12 +12,20 @@ public class HeadingIdAttributeProvider implements AttributeProvider {
 
     private final IdGenerator idGenerator;
 
-    private HeadingIdAttributeProvider() {
-        idGenerator = IdGenerator.builder().defaultId("heading").build();
+    private HeadingIdAttributeProvider(String defaultId, String prefix, String suffix) {
+        idGenerator = IdGenerator.builder()
+                .defaultId(defaultId)
+                .prefix(prefix)
+                .suffix(suffix)
+                .build();
     }
 
     public static HeadingIdAttributeProvider create() {
-        return new HeadingIdAttributeProvider();
+        return create("default", "", "");
+    }
+
+    public static HeadingIdAttributeProvider create(String defaultId, String prefix, String suffix) {
+        return new HeadingIdAttributeProvider(defaultId, prefix, suffix);
     }
 
     @Override

--- a/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/internal/HeadingIdAttributeProvider.java
+++ b/commonmark-ext-heading-anchor/src/main/java/org/commonmark/ext/heading/anchor/internal/HeadingIdAttributeProvider.java
@@ -20,10 +20,6 @@ public class HeadingIdAttributeProvider implements AttributeProvider {
                 .build();
     }
 
-    public static HeadingIdAttributeProvider create() {
-        return create("default", "", "");
-    }
-
     public static HeadingIdAttributeProvider create(String defaultId, String prefix, String suffix) {
         return new HeadingIdAttributeProvider(defaultId, prefix, suffix);
     }

--- a/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorConfigurationTest.java
+++ b/commonmark-ext-heading-anchor/src/test/java/org/commonmark/ext/heading/anchor/HeadingAnchorConfigurationTest.java
@@ -1,0 +1,60 @@
+package org.commonmark.ext.heading.anchor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import org.commonmark.Extension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HeadingAnchorConfigurationTest {
+
+    private static final Parser PARSER = Parser.builder().build();
+
+    private HtmlRenderer buildRenderer(String defaultId, String prefix, String suffix) {
+        Extension ext = HeadingAnchorExtension.builder()
+                .defaultId(defaultId)
+                .idPrefix(prefix)
+                .idSuffix(suffix)
+                .build();
+        return HtmlRenderer.builder()
+                .extensions(Arrays.asList(ext))
+                .build();
+    }
+
+    @Test
+    public void testDefaultConfigurationHasNoAdditions() {
+        HtmlRenderer renderer = HtmlRenderer.builder()
+                .extensions(Arrays.asList(HeadingAnchorExtension.create()))
+                .build();
+        assertThat(doRender(renderer, "# "), equalTo("<h1 id=\"id\"></h1>\n"));
+    }
+
+    @Test
+    public void testDefaultIdWhenNoTextOnHeader() {
+        HtmlRenderer renderer = buildRenderer("defid", "", "");
+        assertThat(doRender(renderer, "# "), equalTo("<h1 id=\"defid\"></h1>\n"));
+    }
+
+    @Test
+    public void testPrefixAddedToHeader() {
+        HtmlRenderer renderer = buildRenderer("", "pre-", "");
+        assertThat(doRender(renderer, "# text"), equalTo("<h1 id=\"pre-text\">text</h1>\n"));
+    }
+
+    @Test
+    public void testSuffixAddedToHeader() {
+        HtmlRenderer renderer = buildRenderer("", "", "-post");
+        assertThat(doRender(renderer, "# text"), equalTo("<h1 id=\"text-post\">text</h1>\n"));
+    }
+
+    private String doRender(HtmlRenderer renderer, String text) {
+        return renderer.render(PARSER.parse(text));
+    }
+
+}


### PR DESCRIPTION
* Adds the ability for IdGenerator to be passed in prefixes and suffixes
that will ensure to be added in-front/after every id. This will
allow users to 'namespace' their generated ids to a certain pool.