### PR TITLE
Fix for Heading without space after # 

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 
 public class HeadingParser extends AbstractBlockParser {
 
-    private static Pattern ATX_HEADING = Pattern.compile("^#{1,6}(?:[ \t]+|$)");
+    private static Pattern ATX_HEADING = Pattern.compile("^#{1,6}(?:[ \t]*|$)");
     private static Pattern ATX_TRAILING = Pattern.compile("(^| ) *#+ *$");
     private static Pattern SETEXT_HEADING = Pattern.compile("^(?:=+|-+) *$");
 


### PR DESCRIPTION
`#Heading `

Is not parsed as heading now. Space or tab is needed after #

