### PR TITLE
Support multiple DelimiterProcessors with the same delimiter char

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -135,9 +135,23 @@ public class InlineParserImpl implements InlineParser {
     private static void addDelimiterProcessors(Iterable<DelimiterProcessor> delimiterProcessors, Map<Character, DelimiterProcessor> map) {
         for (DelimiterProcessor delimiterProcessor : delimiterProcessors) {
             char opening = delimiterProcessor.getOpeningCharacter();
-            addDelimiterProcessorForChar(opening, delimiterProcessor, map);
             char closing = delimiterProcessor.getClosingCharacter();
-            if (opening != closing) {
+            if (opening == closing) {
+                DelimiterProcessor old = map.get(opening);
+                if(old != null && old.getOpeningCharacter() == old.getClosingCharacter()) {
+                    StaggeredDelimiterProcessor s;
+                    if(old instanceof StaggeredDelimiterProcessor) s = (StaggeredDelimiterProcessor)old;
+                    else {
+                        s = new StaggeredDelimiterProcessor(opening);
+                        s.add(old);
+                    }
+                    s.add(delimiterProcessor);
+                    map.put(opening, s);
+                } else {
+                    addDelimiterProcessorForChar(opening, delimiterProcessor, map);
+                }
+            } else {
+                addDelimiterProcessorForChar(opening, delimiterProcessor, map);
                 addDelimiterProcessorForChar(closing, delimiterProcessor, map);
             }
         }

--- a/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
+++ b/commonmark/src/main/java/org/commonmark/internal/StaggeredDelimiterProcessor.java
@@ -1,0 +1,80 @@
+package org.commonmark.internal;
+
+import org.commonmark.node.Text;
+import org.commonmark.parser.delimiter.DelimiterProcessor;
+import org.commonmark.parser.delimiter.DelimiterRun;
+
+import java.util.LinkedList;
+import java.util.ListIterator;
+
+/**
+ * An implementation of DelimiterProcessor that dispatches all calls to two or more other DelimiterProcessors
+ * depending on the length of the delimiter run. All child DelimiterProcessors must have different minimum
+ * lengths. A given delimiter run is dispatched to the child with the largest acceptable minimum length. If no
+ * child is applicable, the one with the largest minimum length is chosen.
+ */
+class StaggeredDelimiterProcessor implements DelimiterProcessor {
+
+    private final char delim;
+    private int minLength = 0;
+    private LinkedList<DelimiterProcessor> processors = new LinkedList<>(); // in reverse getMinLength order
+
+    StaggeredDelimiterProcessor(char delim) {
+        this.delim = delim;
+    }
+
+
+    @Override
+    public char getOpeningCharacter() {
+        return delim;
+    }
+
+    @Override
+    public char getClosingCharacter() {
+        return delim;
+    }
+
+    @Override
+    public int getMinLength() {
+        return minLength;
+    }
+
+    void add(DelimiterProcessor dp) {
+        final int len = dp.getMinLength();
+        ListIterator<DelimiterProcessor> it = processors.listIterator();
+        boolean added = false;
+        while(it.hasNext()) {
+            DelimiterProcessor p = it.next();
+            int pLen = p.getMinLength();
+            if(len > pLen) {
+                it.previous();
+                it.add(dp);
+                added = true;
+                break;
+            } else if(len == pLen) {
+                throw new IllegalArgumentException("Cannot add two delimiter processors for char '" + delim + "' and minimum length "+len);
+            }
+        }
+        if(!added) {
+            processors.add(dp);
+            this.minLength = len;
+        }
+    }
+
+    private DelimiterProcessor findProcessor(int len) {
+      for(DelimiterProcessor p : processors) {
+          if(p.getMinLength() <= len) return p;
+      }
+      return processors.getFirst();
+    }
+
+    @Override
+    public int getDelimiterUse(DelimiterRun opener, DelimiterRun closer) {
+      return findProcessor(opener.length()).getDelimiterUse(opener, closer);
+    }
+
+    @Override
+    public void process(Text opener, Text closer, int delimiterUse) {
+      findProcessor(delimiterUse).process(opener, closer, delimiterUse);
+    }
+}


### PR DESCRIPTION
This is a Java version of my Scala implementation that I mentioned in https://github.com/atlassian/commonmark-java/issues/23#issuecomment-268893851.

Previously it was not possible to use the same delimiter char for
different DelimiterProcessors even if they require a different number of
delimiters (for example, using `~` for subscript together with `~~` for
strikethrough). This change adds support for multiple
DelimiterProcessors with the same delimiter char as long as all
DelimiterProcessors for that char have the same opening and closing
char and different minimum lengths. When multiple processors are defined
for a char, the one with the largest acceptable minimum length is
chosen in each case.