### PR TITLE
Adding ext-heading-anchor to dependencyManagement in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
             </dependency>
             <dependency>
                 <groupId>com.atlassian.commonmark</groupId>
+                <artifactId>commonmark-ext-heading-anchor</artifactId>
+                <version>0.8.1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.atlassian.commonmark</groupId>
                 <artifactId>commonmark-ext-yaml-front-matter</artifactId>
                 <version>0.8.1-SNAPSHOT</version>
             </dependency>


### PR DESCRIPTION
All other child modules listed in the parent pom have a version specified in <dependencyManagement> except `commonmark-ext-heading-anchor`. This makes it difficult to operate with the following setup:

```xml
<dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>com.atlassian.commonmark</groupId>
        <artifactId>commonmark-parent</artifactId>
        <version>0.8.0</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
</dependencyManagement>
<!-- ... -->
<dependencies>
    <dependency>
      <!-- imports correctly due to version specification in parent pom -->
      <groupId>com.atlassian.commonmark</groupId>
      <artifactId>commonmark</artifactId>
    </dependency>
    <dependency>
      <!-- this will fail due to missing version -->
      <groupId>com.atlassian.commonmark</groupId>
      <artifactId>commonmark-ext-heading-anchor</artifactId>
    </dependency>
</dependencies>
```