### PR TITLE
Update text content renderer

### DIFF
--- a/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
@@ -2,6 +2,8 @@ package org.commonmark.renderer.text;
 
 import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
+import org.commonmark.renderer.text.holder.BulletListHolder;
+import org.commonmark.renderer.text.holder.OrderedListHolder;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -15,10 +17,8 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
     protected final TextContentNodeRendererContext context;
     private final TextContentWriter textContent;
 
-    private Integer orderedListCounter;
-    private Character orderedListDelimiter;
-
-    private Character bulletListMarker;
+    private OrderedListHolder orderedListHolder;
+    private BulletListHolder bulletListHolder;
 
     public CoreTextContentNodeRenderer(TextContentNodeRendererContext context) {
         this.context = context;
@@ -68,15 +68,22 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
         visitChildren(blockQuote);
         textContent.write('»');
 
-        writeEndOfLine(blockQuote, null);
+        writeEndOfLineIfNeeded(blockQuote, null);
     }
 
     @Override
     public void visit(BulletList bulletList) {
-        bulletListMarker = bulletList.getBulletMarker();
+        if (bulletListHolder != null) {
+            writeEndOfLine();
+        }
+        bulletListHolder = new BulletListHolder(bulletListHolder, bulletList);
         visitChildren(bulletList);
-        writeEndOfLine(bulletList, null);
-        bulletListMarker = null;
+        writeEndOfLineIfNeeded(bulletList, null);
+        if (bulletListHolder.getParent() != null) {
+            bulletListHolder = (BulletListHolder) bulletListHolder.getParent();
+        } else {
+            bulletListHolder = null;
+        }
     }
 
     @Override
@@ -90,7 +97,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
     public void visit(FencedCodeBlock fencedCodeBlock) {
         if (context.stripNewlines()) {
             textContent.writeStripped(fencedCodeBlock.getLiteral());
-            writeEndOfLine(fencedCodeBlock, null);
+            writeEndOfLineIfNeeded(fencedCodeBlock, null);
         } else {
             textContent.write(fencedCodeBlock.getLiteral());
         }
@@ -98,13 +105,13 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
 
     @Override
     public void visit(HardLineBreak hardLineBreak) {
-        writeEndOfLine(hardLineBreak, null);
+        writeEndOfLineIfNeeded(hardLineBreak, null);
     }
 
     @Override
     public void visit(Heading heading) {
         visitChildren(heading);
-        writeEndOfLine(heading, ':');
+        writeEndOfLineIfNeeded(heading, ':');
     }
 
     @Override
@@ -112,7 +119,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
         if (!context.stripNewlines()) {
             textContent.write("***");
         }
-        writeEndOfLine(thematicBreak, null);
+        writeEndOfLineIfNeeded(thematicBreak, null);
     }
 
     @Override
@@ -134,7 +141,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
     public void visit(IndentedCodeBlock indentedCodeBlock) {
         if (context.stripNewlines()) {
             textContent.writeStripped(indentedCodeBlock.getLiteral());
-            writeEndOfLine(indentedCodeBlock, null);
+            writeEndOfLineIfNeeded(indentedCodeBlock, null);
         } else {
             textContent.write(indentedCodeBlock.getLiteral());
         }
@@ -147,28 +154,34 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
 
     @Override
     public void visit(ListItem listItem) {
-        if (orderedListCounter != null) {
-            textContent.write(String.valueOf(orderedListCounter) + orderedListDelimiter + " ");
+        if (orderedListHolder != null) {
+            String indent = context.stripNewlines() ? "" : orderedListHolder.getIndent();
+            textContent.write(indent + orderedListHolder.getCounter() + orderedListHolder.getDelimiter() + " ");
             visitChildren(listItem);
-            writeEndOfLine(listItem, null);
-            orderedListCounter++;
-        } else if (bulletListMarker != null) {
+            writeEndOfLineIfNeeded(listItem, null);
+            orderedListHolder.increaseCounter();
+        } else if (bulletListHolder != null) {
             if (!context.stripNewlines()) {
-                textContent.write(bulletListMarker + " ");
+                textContent.write(bulletListHolder.getIndent() + bulletListHolder.getMarker() + " ");
             }
             visitChildren(listItem);
-            writeEndOfLine(listItem, null);
+            writeEndOfLineIfNeeded(listItem, null);
         }
     }
 
     @Override
     public void visit(OrderedList orderedList) {
-        orderedListCounter = orderedList.getStartNumber();
-        orderedListDelimiter = orderedList.getDelimiter();
+        if (orderedListHolder != null) {
+            writeEndOfLine();
+        }
+        orderedListHolder = new OrderedListHolder(orderedListHolder, orderedList);
         visitChildren(orderedList);
-        writeEndOfLine(orderedList, null);
-        orderedListCounter = null;
-        orderedListDelimiter = null;
+        writeEndOfLineIfNeeded(orderedList, null);
+        if (orderedListHolder.getParent() != null) {
+            orderedListHolder = (OrderedListHolder) orderedListHolder.getParent();
+        } else {
+            orderedListHolder = null;
+        }
     }
 
     @Override
@@ -176,13 +189,13 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
         visitChildren(paragraph);
         // Add "end of line" only if its "root paragraph.
         if (paragraph.getParent() == null || paragraph.getParent() instanceof Document) {
-            writeEndOfLine(paragraph, null);
+            writeEndOfLineIfNeeded(paragraph, null);
         }
     }
 
     @Override
     public void visit(SoftLineBreak softLineBreak) {
-        writeEndOfLine(softLineBreak, null);
+        writeEndOfLineIfNeeded(softLineBreak, null);
     }
 
     @Override
@@ -240,7 +253,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
         }
     }
 
-    private void writeEndOfLine(Node node, Character c) {
+    private void writeEndOfLineIfNeeded(Node node, Character c) {
         if (context.stripNewlines()) {
             if (c != null) {
                 textContent.write(c);
@@ -252,6 +265,14 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
             if (node.getNext() != null) {
                 textContent.line();
             }
+        }
+    }
+
+    private void writeEndOfLine() {
+        if (context.stripNewlines()) {
+            textContent.whitespace();
+        } else {
+            textContent.line();
         }
     }
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
@@ -223,7 +223,7 @@ public class CoreTextContentNodeRenderer extends AbstractVisitor implements Node
 
     private void writeLink(Node node, String title, String destination) {
         boolean hasChild = node.getFirstChild() != null;
-        boolean hasTitle = title != null;
+        boolean hasTitle = title != null && !title.equals(destination);
         boolean hasDestination = destination != null && !destination.equals("");
 
         if (hasChild) {

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentWriter.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentWriter.java
@@ -31,7 +31,7 @@ public class TextContentWriter {
     }
 
     public void writeStripped(String s) {
-        append(s.replaceAll("[\\r\\n\\s]+", " ").trim());
+        append(s.replaceAll("[\\r\\n\\s]+", " "));
     }
 
     public void write(String s) {

--- a/commonmark/src/main/java/org/commonmark/renderer/text/holder/BulletListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/holder/BulletListHolder.java
@@ -5,7 +5,7 @@ import org.commonmark.node.BulletList;
 public class BulletListHolder extends ListHolder {
     private final char marker;
 
-    public BulletListHolder(BulletListHolder parent, BulletList list) {
+    public BulletListHolder(ListHolder parent, BulletList list) {
         super(parent);
         marker = list.getBulletMarker();
     }

--- a/commonmark/src/main/java/org/commonmark/renderer/text/holder/BulletListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/holder/BulletListHolder.java
@@ -1,0 +1,16 @@
+package org.commonmark.renderer.text.holder;
+
+import org.commonmark.node.BulletList;
+
+public class BulletListHolder extends ListHolder {
+    private final char marker;
+
+    public BulletListHolder(BulletListHolder parent, BulletList list) {
+        super(parent);
+        marker = list.getBulletMarker();
+    }
+
+    public char getMarker() {
+        return marker;
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/text/holder/ListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/holder/ListHolder.java
@@ -1,0 +1,27 @@
+package org.commonmark.renderer.text.holder;
+
+abstract class ListHolder {
+    private static final String INDENT_DEFAULT = "   ";
+    private static final String INDENT_EMPTY = "";
+
+    private final ListHolder parent;
+    private final String indent;
+
+    ListHolder(ListHolder parent) {
+        this.parent = parent;
+
+        if (parent != null) {
+            indent = parent.indent + INDENT_DEFAULT;
+        } else {
+            indent = INDENT_EMPTY;
+        }
+    }
+
+    public ListHolder getParent() {
+        return parent;
+    }
+
+    public String getIndent() {
+        return indent;
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/renderer/text/holder/ListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/holder/ListHolder.java
@@ -1,6 +1,6 @@
 package org.commonmark.renderer.text.holder;
 
-abstract class ListHolder {
+public abstract class ListHolder {
     private static final String INDENT_DEFAULT = "   ";
     private static final String INDENT_EMPTY = "";
 

--- a/commonmark/src/main/java/org/commonmark/renderer/text/holder/OrderedListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/holder/OrderedListHolder.java
@@ -6,7 +6,7 @@ public class OrderedListHolder extends ListHolder {
     private final char delimiter;
     private int counter;
 
-    public OrderedListHolder(OrderedListHolder parent, OrderedList list) {
+    public OrderedListHolder(ListHolder parent, OrderedList list) {
         super(parent);
         delimiter = list.getDelimiter();
         counter = list.getStartNumber();

--- a/commonmark/src/main/java/org/commonmark/renderer/text/holder/OrderedListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/holder/OrderedListHolder.java
@@ -1,0 +1,26 @@
+package org.commonmark.renderer.text.holder;
+
+import org.commonmark.node.OrderedList;
+
+public class OrderedListHolder extends ListHolder {
+    private final char delimiter;
+    private int counter;
+
+    public OrderedListHolder(OrderedListHolder parent, OrderedList list) {
+        super(parent);
+        delimiter = list.getDelimiter();
+        counter = list.getStartNumber();
+    }
+
+    public char getDelimiter() {
+        return delimiter;
+    }
+
+    public int getCounter() {
+        return counter;
+    }
+
+    public void increaseCounter() {
+        counter++;
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -10,129 +10,224 @@ import static org.junit.Assert.assertEquals;
 public class TextContentRendererTest {
 
     @Test
-    public void textContentEmphasis() {
+    public void textContentText() {
+        String source;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo\n***foo***\nbar\n\n***bar***"));
-        assertEquals("foo\nfoo\nbar\nbar", rendered);
+        source = "foo bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("foo bar", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("foo bar", rendered);
 
-        rendered = strippedRenderer().render(parse("foo\n***foo\nbar***\n\n***bar***"));
+        source = "foo foo\n\nbar\nbar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("foo foo\nbar\nbar", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("foo foo bar bar", rendered);
+    }
+
+    @Test
+    public void textContentEmphasis() {
+        String source;
+        String rendered;
+
+        source = "***foo***";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("foo", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("foo", rendered);
+
+        source = "foo ***foo*** bar ***bar***";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("foo foo bar bar", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("foo foo bar bar", rendered);
+
+        source = "foo\n***foo***\nbar\n\n***bar***";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("foo\nfoo\nbar\nbar", rendered);
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo foo bar bar", rendered);
     }
 
     @Test
     public void textContentQuotes() {
+        String source;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo\n>foo\nbar\n\nbar"));
+        source = "foo\n>foo\nbar\n\nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\n«foo\nbar»\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo\n>foo\nbar\n\nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo «foo bar» bar", rendered);
     }
 
     @Test
     public void textContentLinks() {
+        String source;
+        String expected;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo [text](http://link \"title\") bar"));
-        assertEquals("foo \"text\" (title: http://link) bar", rendered);
+        source = "foo [text](http://link \"title\") bar";
+        expected = "foo \"text\" (title: http://link) bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
 
-        rendered = defaultRenderer().render(parse("foo [text](http://link) bar"));
-        assertEquals("foo \"text\" (http://link) bar", rendered);
+        source = "foo [text](http://link \"http://link\") bar";
+        expected = "foo \"text\" (http://link) bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
 
-        rendered = defaultRenderer().render(parse("foo [text]() bar"));
-        assertEquals("foo \"text\" bar", rendered);
+        source = "foo [text](http://link) bar";
+        expected = "foo \"text\" (http://link) bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
 
-        rendered = defaultRenderer().render(parse("foo http://link bar"));
-        assertEquals("foo http://link bar", rendered);
+        source = "foo [text]() bar";
+        expected = "foo \"text\" bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+
+        source = "foo http://link bar";
+        expected = "foo http://link bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
     }
 
     @Test
     public void textContentImages() {
+        String source;
+        String expected;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo ![text](http://link \"title\") bar"));
-        assertEquals("foo \"text\" (title: http://link) bar", rendered);
+        source = "foo ![text](http://link \"title\") bar";
+        expected = "foo \"text\" (title: http://link) bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
 
-        rendered = defaultRenderer().render(parse("foo ![text](http://link) bar"));
-        assertEquals("foo \"text\" (http://link) bar", rendered);
+        source = "foo ![text](http://link) bar";
+        expected = "foo \"text\" (http://link) bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
 
-        rendered = defaultRenderer().render(parse("foo ![text]() bar"));
-        assertEquals("foo \"text\" bar", rendered);
+        source = "foo ![text]() bar";
+        expected = "foo \"text\" bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
     }
 
     @Test
     public void textContentLists() {
+        String source;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo\n* foo\n* bar\n\nbar"));
+        source = "foo\n* foo\n* bar\n\nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\n* foo\n* bar\nbar", rendered);
-
-        rendered = defaultRenderer().render(parse("foo\n- foo\n- bar\n\nbar"));
-        assertEquals("foo\n- foo\n- bar\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo\n* foo\n* bar\n\nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo foo bar bar", rendered);
 
-        rendered = defaultRenderer().render(parse("foo\n1. foo\n2. bar\n\nbar"));
+        source = "foo\n- foo\n- bar\n\nbar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("foo\n- foo\n- bar\nbar", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("foo foo bar bar", rendered);
+
+        source = "foo\n1. foo\n2. bar\n\nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\n1. foo\n2. bar\nbar", rendered);
-
-        rendered = defaultRenderer().render(parse("foo\n0) foo\n1) bar\n\nbar"));
-        assertEquals("foo\n0) foo\n1) bar\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo\n1. foo\n2. bar\n\nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo 1. foo 2. bar bar", rendered);
 
-        rendered = strippedRenderer().render(parse("foo\n0) foo\n1) bar\n\nbar"));
+        source = "foo\n0) foo\n1) bar\n\nbar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("foo\n0) foo\n1) bar\nbar", rendered);
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo 0) foo 1) bar bar", rendered);
+
+        source = "bar\n1. foo\n   1. bar\n2. foo";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("bar\n1. foo\n   1. bar\n2. foo", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("bar 1. foo 1. bar 2. foo", rendered);
+
+        source = "bar\n* foo\n   - bar\n* foo";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("bar\n* foo\n   - bar\n* foo", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("bar foo bar foo", rendered);
     }
 
     @Test
     public void textContentCode() {
+        String source;
+        String expected;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo `code` bar"));
-        assertEquals("foo \"code\" bar", rendered);
+        source = "foo `code` bar";
+        expected = "foo \"code\" bar";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals(expected, rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals(expected, rendered);
     }
 
     @Test
     public void textContentCodeBlock() {
+        String source;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo\n```\nfoo\nbar\n```\nbar"));
+        source = "foo\n```\nfoo\nbar\n```\nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\nfoo\nbar\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo\n```\nfoo\nbar\n```\nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo foo bar bar", rendered);
 
-        rendered = defaultRenderer().render(parse("foo\n\n    foo\n     bar\nbar"));
+        source = "foo\n\n    foo\n     bar\nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\nfoo\n bar\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo\n\n    foo\n     bar\nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo foo bar bar", rendered);
     }
 
     @Test
     public void textContentBrakes() {
+        String source;
         String rendered;
 
-        rendered = defaultRenderer().render(parse("foo\nbar"));
+        source = "foo\nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo\nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo bar", rendered);
 
-        rendered = defaultRenderer().render(parse("foo  \nbar"));
+        source = "foo  \nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo  \nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo bar", rendered);
 
-        rendered = defaultRenderer().render(parse("foo\n___\nbar"));
+        source = "foo\n___\nbar";
+        rendered = defaultRenderer().render(parse(source));
         assertEquals("foo\n***\nbar", rendered);
-
-        rendered = strippedRenderer().render(parse("foo\n___\nbar"));
+        rendered = strippedRenderer().render(parse(source));
         assertEquals("foo bar", rendered);
     }
 

--- a/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentRendererTest.java
@@ -173,6 +173,18 @@ public class TextContentRendererTest {
         assertEquals("bar\n* foo\n   - bar\n* foo", rendered);
         rendered = strippedRenderer().render(parse(source));
         assertEquals("bar foo bar foo", rendered);
+
+        source = "bar\n* foo\n   1. bar\n   2. bar\n* foo";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("bar\n* foo\n   1. bar\n   2. bar\n* foo", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("bar foo 1. bar 2. bar foo", rendered);
+
+        source = "bar\n1. foo\n   * bar\n   * bar\n2. foo";
+        rendered = defaultRenderer().render(parse(source));
+        assertEquals("bar\n1. foo\n   * bar\n   * bar\n2. foo", rendered);
+        rendered = strippedRenderer().render(parse(source));
+        assertEquals("bar 1. foo bar bar 2. foo", rendered);
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/test/TextContentWriterTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/TextContentWriterTest.java
@@ -41,7 +41,7 @@ public class TextContentWriterTest {
     public void writeStripped() throws Exception {
         StringBuilder stringBuilder = new StringBuilder();
         TextContentWriter writer = new TextContentWriter(stringBuilder);
-        writer.writeStripped("foo\n bar\n");
+        writer.writeStripped("foo\n bar");
         assertEquals("foo bar", stringBuilder.toString());
     }
 


### PR DESCRIPTION
This PR add some fixes/improvements for text content rendering:
1. Added support for sub lists
2. Fixed that whitespaces between text elements are removed in "stripped" mode. For example `**text** and text` had rendered as `textand text`
3. Improved rendering for auto links