### PR TITLE
Fix text node merging when opening/closing delimiters are adjacent (#96)

### DIFF
--- a/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/DelimiterProcessorTest.java
@@ -45,6 +45,7 @@ public class DelimiterProcessorTest extends RenderingTestCase {
         assertRendering("}foo} bar", "<p>}foo} bar</p>\n");
         assertRendering("{foo{ bar", "<p>{foo{ bar</p>\n");
         assertRendering("}foo{ bar", "<p>}foo{ bar</p>\n");
+        assertRendering("{} {foo}", "<p> FOO</p>\n");
     }
 
     @Test


### PR DESCRIPTION
When using asymmetric delimiters, e.g. `{` as an opener and `}` as a
closer, the input `{}` means there are no nodes between the delimiters.
So we have the following nodes:

1. `{` (opener)
2. `}` (closer)

The code to merge text nodes was merging nodes starting from opener.next
and ending with closer.previous. In the above situation, that would mean
merging starting from "2" (and ending at "1"). Because it never got to
node "1", it would just keep merging nodes until the end of the block.

The NPE in #96 is a possible symptom of that. In other cases, delimiter
processing might lead to the wrong result.