### PR TITLE
Move text renderer util classes to internal package

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/renderer/text/BulletListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/internal/renderer/text/BulletListHolder.java
@@ -1,4 +1,4 @@
-package org.commonmark.renderer.text.holder;
+package org.commonmark.internal.renderer.text;
 
 import org.commonmark.node.BulletList;
 

--- a/commonmark/src/main/java/org/commonmark/internal/renderer/text/ListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/internal/renderer/text/ListHolder.java
@@ -1,4 +1,4 @@
-package org.commonmark.renderer.text.holder;
+package org.commonmark.internal.renderer.text;
 
 public abstract class ListHolder {
     private static final String INDENT_DEFAULT = "   ";

--- a/commonmark/src/main/java/org/commonmark/internal/renderer/text/OrderedListHolder.java
+++ b/commonmark/src/main/java/org/commonmark/internal/renderer/text/OrderedListHolder.java
@@ -1,4 +1,4 @@
-package org.commonmark.renderer.text.holder;
+package org.commonmark.internal.renderer.text;
 
 import org.commonmark.node.OrderedList;
 

--- a/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/CoreTextContentNodeRenderer.java
@@ -2,9 +2,9 @@ package org.commonmark.renderer.text;
 
 import org.commonmark.node.*;
 import org.commonmark.renderer.NodeRenderer;
-import org.commonmark.renderer.text.holder.BulletListHolder;
-import org.commonmark.renderer.text.holder.ListHolder;
-import org.commonmark.renderer.text.holder.OrderedListHolder;
+import org.commonmark.internal.renderer.text.BulletListHolder;
+import org.commonmark.internal.renderer.text.ListHolder;
+import org.commonmark.internal.renderer.text.OrderedListHolder;
 
 import java.util.Arrays;
 import java.util.HashSet;


### PR DESCRIPTION
They are not API, so they should be in an internal package.

@JinneeJ small post-merge cleanup, please review :).