### PR TITLE
Switch to codecov for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,12 @@ android:
     - extra-android-m2repository
     - sys-img-armeabi-v7a-android-16
 script:
-  - 'if [[ $TEST = java ]]; then mvn test -Dsurefire.useFile=false; fi'
-  - 'if [[ $TEST = android ]]; then mvn install -DskipTests && cd commonmark-android-test && travis_retry ./.travis.sh; fi'
-deploy:
-  provider: script
-  script: mvn clean test coveralls:report -Pcoverage
-  on:
-    jdk: oraclejdk8
-    condition: "$TEST = java"
+  - 'if [ $TEST = java ]; then mvn test -Dsurefire.useFile=false; fi'
+  - 'if [ $TEST = android ]; then mvn install -DskipTests && cd commonmark-android-test && travis_retry ./.travis.sh; fi'
+
+after_success: |
+  if [ $TRAVIS_JDK_VERSION = oraclejdk8 ] && [ $TEST = java ]; then
+    # Calculate test coverage
+    mvn clean test jacoco:report -Pcoverage
+    bash <(curl -s https://codecov.io/bash)
+  fi

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ commonmark-java
 Java library for parsing and rendering [Markdown] text according to the
 [CommonMark] specification (and some extensions).
 
+[![Maven Central status](https://img.shields.io/maven-central/v/com.atlassian.commonmark/commonmark.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.atlassian.commonmark%22)
+[![Build status](https://travis-ci.org/atlassian/commonmark-java.svg?branch=master)](https://travis-ci.org/atlassian/commonmark-java)
+[![codecov](https://codecov.io/gh/atlassian/commonmark-java/branch/master/graph/badge.svg)](https://codecov.io/gh/atlassian/commonmark-java)
+
+Introduction
+------------
+
 Provides classes for parsing input to an abstract syntax tree of nodes
 (AST), visiting and manipulating nodes, and rendering to HTML. It
 started out as a port of [commonmark.js], but has since evolved into a
@@ -38,10 +45,6 @@ See the [spec.txt](commonmark-test-util/src/main/resources/spec.txt)
 file if you're wondering which version of the spec is currently
 implemented. Also check out the [CommonMark dingus] for getting familiar
 with the syntax or trying out edge cases.
-
-[![Build status](https://travis-ci.org/atlassian/commonmark-java.svg?branch=master)](https://travis-ci.org/atlassian/commonmark-java)
-[![Coverage status](https://coveralls.io/repos/github/atlassian/commonmark-java/badge.svg?branch=master)](https://coveralls.io/github/atlassian/commonmark-java?branch=master)
-[![Maven Central status](https://img.shields.io/maven-central/v/com.atlassian.commonmark/commonmark.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.atlassian.commonmark%22)
 
 
 Usage

--- a/commonmark-integration-test/pom.xml
+++ b/commonmark-integration-test/pom.xml
@@ -61,33 +61,6 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <configuration>
-                            <!-- This is where coveralls expects the files to be, so just put it there. -->
-                            <outputDirectory>${project.parent.reporting.outputDirectory}/jacoco</outputDirectory>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>report-aggregate</id>
-                                <goals>
-                                    <goal>report-aggregate</goal>
-                                </goals>
-                                <phase>test</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -159,11 +159,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.eluder.coveralls</groupId>
-                        <artifactId>coveralls-maven-plugin</artifactId>
-                        <version>4.3.0</version>
-                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
* Simpler to integrate
* UI looks nicer for browsing and understanding coverage
* It can post a PR comment with the coverage diff (we'll see how useful it is)