### PR TITLE
Update table delimiter row to GFM spec

### DIFF
--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 public class TableBlockParser extends AbstractBlockParser {
 
-    private static String COL = "\\s*:?-{3,}:?\\s*";
+    private static String COL = "\\s*:?-{1,}:?\\s*";
     private static Pattern TABLE_HEADER_SEPARATOR = Pattern.compile(
             // For single column, require at least one pipe, otherwise it's ambiguous with setext headers
             "\\|" + COL + "\\|?\\s*" + "|" +

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -30,9 +30,26 @@ public class TablesTest extends RenderingTestCase {
     }
 
     @Test
-    public void separatorMustBeThreeOrMore() {
-        assertRendering("Abc|Def\n-|-", "<p>Abc|Def\n-|-</p>\n");
-        assertRendering("Abc|Def\n--|--", "<p>Abc|Def\n--|--</p>\n");
+    public void separatorMustBeOneOrMore() {
+        assertRendering("Abc|Def\n-|-", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th>Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody></tbody>\n" +
+                "</table>\n");
+        assertRendering("Abc|Def\n--|--", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th>Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody></tbody>\n" +
+                "</table>\n");
+    }
+
+    @Test
+    public void separatorMustNotContainInvalidChars() {
+        assertRendering("Abc|Def\n |-a-|---", "<p>Abc|Def\n|-a-|---</p>\n");
+        assertRendering("Abc|Def\n |:--a|---", "<p>Abc|Def\n|:--a|---</p>\n");
+        assertRendering("Abc|Def\n |:--a--:|---", "<p>Abc|Def\n|:--a--:|---</p>\n");
     }
 
     @Test
@@ -191,6 +208,22 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void alignLeft() {
+        assertRendering("Abc|Def\n:-|-\n1|2", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th align=\"left\">Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr><td align=\"left\">1</td><td>2</td></tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
+        assertRendering("Abc|Def\n:-|-\n1|2", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th align=\"left\">Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr><td align=\"left\">1</td><td>2</td></tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
         assertRendering("Abc|Def\n:---|---\n1|2", "<table>\n" +
                 "<thead>\n" +
                 "<tr><th align=\"left\">Abc</th><th>Def</th></tr>\n" +
@@ -203,6 +236,22 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void alignRight() {
+        assertRendering("Abc|Def\n-:|-\n1|2", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th align=\"right\">Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr><td align=\"right\">1</td><td>2</td></tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
+        assertRendering("Abc|Def\n--:|--\n1|2", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th align=\"right\">Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr><td align=\"right\">1</td><td>2</td></tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
         assertRendering("Abc|Def\n---:|---\n1|2", "<table>\n" +
                 "<thead>\n" +
                 "<tr><th align=\"right\">Abc</th><th>Def</th></tr>\n" +
@@ -215,6 +264,22 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void alignCenter() {
+        assertRendering("Abc|Def\n:-:|-\n1|2", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th align=\"center\">Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr><td align=\"center\">1</td><td>2</td></tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
+        assertRendering("Abc|Def\n:--:|--\n1|2", "<table>\n" +
+                "<thead>\n" +
+                "<tr><th align=\"center\">Abc</th><th>Def</th></tr>\n" +
+                "</thead>\n" +
+                "<tbody>\n" +
+                "<tr><td align=\"center\">1</td><td>2</td></tr>\n" +
+                "</tbody>\n" +
+                "</table>\n");
         assertRendering("Abc|Def\n:---:|---\n1|2", "<table>\n" +
                 "<thead>\n" +
                 "<tr><th align=\"center\">Abc</th><th>Def</th></tr>\n" +


### PR DESCRIPTION
The GFM spec states that any table delimiter row is valid if it contains at
least one `-` and no other characters except for whitespace and `:`.

See: https://github.github.com/gfm/#tables-extension-

I have signed the CLA for individuals. 

This addresses part of #84 