### PR TITLE
Add regression tests from cmark and commonmark.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## Unreleased
+### Changed
+- Parse backslash followed by unescapable character the same way as
+  the reference implementations.
+### Fixed
+- Fix tab handling in ATX and Setext headings.
+
 ## [0.11.0] - 2018-01-17
 ### Added
 - The extension for tables now also renders to plain text

--- a/commonmark-android-test/app/src/androidTest/java/com/atlassian/commonmark/android/test/AndroidSupportTest.java
+++ b/commonmark-android-test/app/src/androidTest/java/com/atlassian/commonmark/android/test/AndroidSupportTest.java
@@ -10,7 +10,7 @@ import org.commonmark.ext.ins.InsExtension;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
-import org.commonmark.testutil.spec.SpecReader;
+import org.commonmark.testutil.TestResources;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +30,7 @@ public class AndroidSupportTest {
 
     @Before
     public void setUp() throws Exception {
-        spec = SpecReader.readSpec();
+        spec = TestResources.readAsString(TestResources.getSpec());
     }
 
     @Test

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/BoundsIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/BoundsIntegrationTest.java
@@ -2,8 +2,9 @@ package org.commonmark.integration;
 
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
-import org.commonmark.testutil.spec.SpecExample;
-import org.commonmark.testutil.spec.SpecReader;
+import org.commonmark.testutil.TestResources;
+import org.commonmark.testutil.example.Example;
+import org.commonmark.testutil.example.ExampleReader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -29,9 +30,9 @@ public class BoundsIntegrationTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static List<Object[]> data() {
-        List<SpecExample> examples = SpecReader.readExamples();
+        List<Example> examples = ExampleReader.readExamples(TestResources.getSpec());
         List<Object[]> data = new ArrayList<>();
-        for (SpecExample example : examples) {
+        for (Example example : examples) {
             data.add(new Object[]{example.getSource()});
         }
         return data;

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/PegDownBenchmark.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/PegDownBenchmark.java
@@ -1,6 +1,7 @@
 package org.commonmark.integration;
 
-import org.commonmark.testutil.spec.SpecReader;
+import org.commonmark.testutil.TestResources;
+import org.commonmark.testutil.example.ExampleReader;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -17,8 +18,8 @@ import java.util.List;
 @State(Scope.Benchmark)
 public class PegDownBenchmark {
 
-    private static final String SPEC = SpecReader.readSpec();
-    private static final List<String> SPEC_EXAMPLES = SpecReader.readExamplesAsString();
+    private static final String SPEC = TestResources.readAsString(TestResources.getSpec());
+    private static final List<String> SPEC_EXAMPLES = ExampleReader.readExampleSources(TestResources.getSpec());
     private static final PegDownProcessor PROCESSOR = new PegDownProcessor(Extensions.FENCED_CODE_BLOCKS);
 
     public static void main(String[] args) throws Exception {

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
@@ -8,7 +8,7 @@ import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.ext.front.matter.YamlFrontMatterExtension;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.parser.Parser;
-import org.commonmark.testutil.spec.SpecExample;
+import org.commonmark.testutil.example.Example;
 import org.commonmark.testutil.SpecTestCase;
 import org.junit.Test;
 
@@ -30,7 +30,7 @@ public class SpecIntegrationTest extends SpecTestCase {
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).percentEncodeUrls(true).build();
     private static final Map<String, String> OVERRIDDEN_EXAMPLES = getOverriddenExamples();
 
-    public SpecIntegrationTest(SpecExample example) {
+    public SpecIntegrationTest(Example example) {
         super(example);
     }
 

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/SpecTestCase.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/SpecTestCase.java
@@ -1,7 +1,7 @@
 package org.commonmark.testutil;
 
-import org.commonmark.testutil.spec.SpecExample;
-import org.commonmark.testutil.spec.SpecReader;
+import org.commonmark.testutil.example.Example;
+import org.commonmark.testutil.example.ExampleReader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -13,17 +13,17 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public abstract class SpecTestCase extends RenderingTestCase {
 
-    protected final SpecExample example;
+    protected final Example example;
 
-    public SpecTestCase(SpecExample example) {
+    public SpecTestCase(Example example) {
         this.example = example;
     }
 
     @Parameters(name = "{0}")
     public static List<Object[]> data() {
-        List<SpecExample> examples = SpecReader.readExamples();
+        List<Example> examples = ExampleReader.readExamples(TestResources.getSpec());
         List<Object[]> data = new ArrayList<>();
-        for (SpecExample example : examples) {
+        for (Example example : examples) {
             data.add(new Object[]{example});
         }
         return data;

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/TestResources.java
@@ -1,0 +1,37 @@
+package org.commonmark.testutil;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestResources {
+
+    public static URL getSpec() {
+        return TestResources.class.getResource("/spec.txt");
+    }
+
+    public static List<URL> getRegressions() {
+        return Arrays.asList(
+                TestResources.class.getResource("/cmark-regression.txt"),
+                TestResources.class.getResource("/commonmark.js-regression.txt")
+        );
+    }
+
+    public static String readAsString(URL url) {
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), Charset.forName("UTF-8")))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+                sb.append("\n");
+            }
+            return sb.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/example/Example.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/example/Example.java
@@ -1,13 +1,15 @@
-package org.commonmark.testutil.spec;
+package org.commonmark.testutil.example;
 
-public class SpecExample {
+public class Example {
 
+    private final String filename;
     private final String section;
     private final int exampleNumber;
     private final String source;
     private final String html;
 
-    public SpecExample(String section, int exampleNumber, String source, String html) {
+    public Example(String filename, String section, int exampleNumber, String source, String html) {
+        this.filename = filename;
         this.section = section;
         this.exampleNumber = exampleNumber;
         this.source = source;
@@ -24,6 +26,6 @@ public class SpecExample {
 
     @Override
     public String toString() {
-        return "Section \"" + section + "\" example " + exampleNumber;
+        return "File \"" + filename + "\" section \"" + section + "\" example " + exampleNumber;
     }
 }

--- a/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
+++ b/commonmark-test-util/src/main/java/org/commonmark/testutil/example/ExampleReader.java
@@ -1,20 +1,22 @@
-package org.commonmark.testutil.spec;
+package org.commonmark.testutil.example;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class SpecReader {
+/**
+ * Reader for files containing examples of CommonMark source and the expected HTML rendering (e.g. spec.txt).
+ */
+public class ExampleReader {
 
     private static final Pattern SECTION_PATTERN = Pattern.compile("#{1,6} *(.*)");
 
     private final InputStream inputStream;
+    private final String filename;
 
     private State state = State.BEFORE;
     private String section;
@@ -22,52 +24,31 @@ public class SpecReader {
     private StringBuilder html;
     private int exampleNumber = 0;
 
-    private List<SpecExample> examples = new ArrayList<>();
+    private List<Example> examples = new ArrayList<>();
 
-    private SpecReader(InputStream stream) {
+    private ExampleReader(InputStream stream, String filename) {
         this.inputStream = stream;
+        this.filename = filename;
     }
 
-    public static List<SpecExample> readExamples() {
-        try (InputStream stream = getSpecInputStream()) {
-            return new SpecReader(stream).read();
+    public static List<Example> readExamples(URL url) {
+        try (InputStream stream = url.openStream()) {
+            return new ExampleReader(stream, new File(url.getPath()).getName()).read();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static List<String> readExamplesAsString() {
-        List<SpecExample> examples = SpecReader.readExamples();
+    public static List<String> readExampleSources(URL url) {
+        List<Example> examples = ExampleReader.readExamples(url);
         List<String> result = new ArrayList<>();
-        for (SpecExample example : examples) {
+        for (Example example : examples) {
             result.add(example.getSource());
         }
         return result;
     }
 
-    public static String readSpec() {
-        StringBuilder sb = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(getSpecInputStream(), Charset.forName("UTF-8")))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                sb.append(line);
-                sb.append("\n");
-            }
-            return sb.toString();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static InputStream getSpecInputStream() {
-        InputStream stream = SpecReader.class.getResourceAsStream("/spec.txt");
-        if (stream == null) {
-            throw new IllegalStateException("Could not load spec.txt classpath resource");
-        }
-        return stream;
-    }
-
-    private List<SpecExample> read() throws IOException {
+    private List<Example> read() throws IOException {
         resetContents();
 
         try (BufferedReader reader = new BufferedReader(
@@ -106,7 +87,7 @@ public class SpecReader {
             case HTML:
                 if (line.equals("````````````````````````````````")) {
                     state = State.BEFORE;
-                    examples.add(new SpecExample(section, exampleNumber,
+                    examples.add(new Example(filename, section, exampleNumber,
                             source.toString(), html.toString()));
                     resetContents();
                 } else {

--- a/commonmark-test-util/src/main/resources/README.md
+++ b/commonmark-test-util/src/main/resources/README.md
@@ -1,0 +1,7 @@
+These files are copied from the CommonMark repositories, namely:
+
+https://github.com/commonmark/CommonMark/blob/master/spec.txt
+https://github.com/commonmark/cmark/blob/master/test/regression.txt
+https://github.com/commonmark/commonmark.js/blob/master/test/regression.txt
+
+They are licensed as stated in those repositories.

--- a/commonmark-test-util/src/main/resources/cmark-regression.txt
+++ b/commonmark-test-util/src/main/resources/cmark-regression.txt
@@ -1,0 +1,95 @@
+### Regression tests
+
+Issue #113: EOL character weirdness on Windows
+(Important: first line ends with CR + CR + LF)
+
+```````````````````````````````` example
+line1
+
+line2
+.
+<p>line1</p>
+<p>line2</p>
+````````````````````````````````
+
+Issue #114: cmark skipping first character in line
+(Important: the blank lines around "Repeatedly" contain a tab.)
+
+```````````````````````````````` example
+By taking it apart
+
+- alternative solutions
+→
+Repeatedly solving
+→
+- how techniques
+.
+<p>By taking it apart</p>
+<ul>
+<li>alternative solutions</li>
+</ul>
+<p>Repeatedly solving</p>
+<ul>
+<li>how techniques</li>
+</ul>
+````````````````````````````````
+
+Issue jgm/CommonMark#430:  h2..h6 not recognized as block tags.
+
+```````````````````````````````` example
+<h1>lorem</h1>
+
+<h2>lorem</h2>
+
+<h3>lorem</h3>
+
+<h4>lorem</h4>
+
+<h5>lorem</h5>
+
+<h6>lorem</h6>
+.
+<h1>lorem</h1>
+<h2>lorem</h2>
+<h3>lorem</h3>
+<h4>lorem</h4>
+<h5>lorem</h5>
+<h6>lorem</h6>
+````````````````````````````````
+
+Issue jgm/commonmark.js#109 - tabs after setext header line
+
+
+```````````````````````````````` example
+hi
+--→
+.
+<h2>hi</h2>
+````````````````````````````````
+
+Issue #177 - incorrect emphasis parsing
+
+```````````````````````````````` example
+a***b* c*
+.
+<p>a*<em><em>b</em> c</em></p>
+````````````````````````````````
+
+Issue #193 - unescaped left angle brackets in link destination
+
+```````````````````````````````` example
+[a]
+
+[a]: <te<st>
+.
+<p><a href="%3Cte%3Cst%3E">a</a></p>
+````````````````````````````````
+
+Issue #192 - escaped spaces in link destination
+
+
+```````````````````````````````` example
+[a](te\ st)
+.
+<p>[a](te\ st)</p>
+````````````````````````````````

--- a/commonmark-test-util/src/main/resources/commonmark.js-regression.txt
+++ b/commonmark-test-util/src/main/resources/commonmark.js-regression.txt
@@ -1,0 +1,104 @@
+# Regression tests
+
+Eating a character after a partially consumed tab.
+
+```````````````````````````````` example
+* foo
+→bar
+.
+<ul>
+<li>foo
+bar</li>
+</ul>
+````````````````````````````````
+
+Type 7 HTML block followed by whitespace (#98).
+
+```````````````````````````````` example
+<a>
+x
+.
+<a>
+x
+````````````````````````````````
+
+h2..h6 raw HTML blocks (jgm/CommonMark#430).
+
+```````````````````````````````` example
+<h1>lorem</h1>
+
+<h2>lorem</h2>
+
+<h3>lorem</h3>
+
+<h4>lorem</h4>
+
+<h5>lorem</h5>
+
+<h6>lorem</h6>
+.
+<h1>lorem</h1>
+<h2>lorem</h2>
+<h3>lorem</h3>
+<h4>lorem</h4>
+<h5>lorem</h5>
+<h6>lorem</h6>
+````````````````````````````````
+
+Issue #109 - tabs after setext header line
+
+
+```````````````````````````````` example
+hi
+--→
+.
+<h2>hi</h2>
+````````````````````````````````
+
+Issue #108 - Chinese punctuation not recognized
+
+```````````````````````````````` example
+**。**话
+.
+<p>**。**话</p>
+````````````````````````````````
+
+Issue jgm/cmark#177 - incorrect emphasis parsing
+
+```````````````````````````````` example
+a***b* c*
+.
+<p>a*<em><em>b</em> c</em></p>
+````````````````````````````````
+
+Issue jgm/CommonMark#468 - backslash at end of link definition
+
+
+```````````````````````````````` example
+[\]: test
+.
+<p>[]: test</p>
+````````````````````````````````
+
+Issue jgm/commonmark.js#121 - punctuation set different
+
+```````````````````````````````` example
+^_test_
+.
+<p>^<em>test</em></p>
+````````````````````````````````
+
+Issue #116 - tabs before and after ATX closing heading
+```````````````````````````````` example
+# foo→#→
+.
+<h1>foo</h1>
+````````````````````````````````
+
+commonmark/CommonMark#493 - escaped space not allowed in link
+destination.
+```````````````````````````````` example
+[link](a\ b)
+.
+<p>[link](a\ b)</p>
+````````````````````````````````

--- a/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
 public class HeadingParser extends AbstractBlockParser {
 
     private static Pattern ATX_HEADING = Pattern.compile("^#{1,6}(?:[ \t]+|$)");
-    private static Pattern ATX_TRAILING = Pattern.compile("(^| ) *#+ *$");
-    private static Pattern SETEXT_HEADING = Pattern.compile("^(?:=+|-+) *$");
+    private static Pattern ATX_TRAILING = Pattern.compile("(^|[ \t]+)#+[ \t]*$");
+    private static Pattern SETEXT_HEADING = Pattern.compile("^(?:=+|-+)[ \t]*$");
 
     private final Heading block = new Heading();
     private final String content;
@@ -54,7 +54,8 @@ public class HeadingParser extends AbstractBlockParser {
                 int newOffset = nextNonSpace + matcher.group(0).length();
                 int level = matcher.group(0).trim().length(); // number of #s
                 // remove trailing ###s:
-                String content = ATX_TRAILING.matcher(line.subSequence(newOffset, line.length())).replaceAll("");
+                CharSequence afterLeading = line.subSequence(newOffset, line.length());
+                String content = ATX_TRAILING.matcher(afterLeading).replaceAll("");
                 return BlockStart.of(new HeadingParser(level, content))
                         .atIndex(line.length());
 

--- a/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
+++ b/commonmark/src/main/java/org/commonmark/internal/InlineParserImpl.java
@@ -648,13 +648,13 @@ public class InlineParserImpl implements InlineParser, ReferenceParser {
                 case '\0':
                     return;
                 case '\\':
-                    // go to character after backslash
-                    index++;
-                    // stop if that took us to the end of input
-                    if (peek() == '\0') {
-                        return;
+                    // check if we have an escapable character
+                    if (index + 1 < input.length() && ESCAPABLE.matcher(input.substring(index + 1, index + 2)).matches()) {
+                        // skip over the escaped character (after switch)
+                        index++;
+                        break;
                     }
-                    // otherwise, we'll skip over character after backslash
+                    // otherwise, we treat this as a literal backslash
                     break;
                 case '(':
                     parens++;

--- a/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/HtmlRendererTest.java
@@ -7,7 +7,7 @@ import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.NodeRenderer;
 import org.commonmark.renderer.html.*;
-import org.commonmark.testutil.spec.SpecReader;
+import org.commonmark.testutil.TestResources;
 import org.junit.Test;
 
 import java.util.*;
@@ -210,7 +210,7 @@ public class HtmlRendererTest {
     @Test
     public void threading() throws Exception {
         Parser parser = Parser.builder().build();
-        String spec = SpecReader.readSpec();
+        String spec = TestResources.readAsString(TestResources.getSpec());
         final Node document = parser.parse(spec);
 
         final HtmlRenderer htmlRenderer = HtmlRenderer.builder().build();

--- a/commonmark/src/test/java/org/commonmark/test/ParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/ParserTest.java
@@ -7,7 +7,7 @@ import org.commonmark.parser.InlineParserFactory;
 import org.commonmark.parser.Parser;
 import org.commonmark.parser.block.*;
 import org.commonmark.renderer.html.HtmlRenderer;
-import org.commonmark.testutil.spec.SpecReader;
+import org.commonmark.testutil.TestResources;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -32,13 +32,13 @@ public class ParserTest {
     public void ioReaderTest() throws IOException {
         Parser parser = Parser.builder().build();
 
-        InputStream input1 = SpecReader.getSpecInputStream();
+        InputStream input1 = TestResources.getSpec().openStream();
         Node document1;
         try (InputStreamReader reader = new InputStreamReader(input1)) {
             document1 = parser.parseReader(reader);
         }
 
-        String spec = SpecReader.readSpec();
+        String spec = TestResources.readAsString(TestResources.getSpec());
         Node document2 = parser.parse(spec);
 
         HtmlRenderer renderer = HtmlRenderer.builder().escapeHtml(true).build();
@@ -124,7 +124,7 @@ public class ParserTest {
     @Test
     public void threading() throws Exception {
         final Parser parser = Parser.builder().build();
-        final String spec = SpecReader.readSpec();
+        final String spec = TestResources.readAsString(TestResources.getSpec());
 
         HtmlRenderer renderer = HtmlRenderer.builder().build();
         String expectedRendering = renderer.render(parser.parse(spec));

--- a/commonmark/src/test/java/org/commonmark/test/RegressionTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/RegressionTest.java
@@ -1,0 +1,52 @@
+package org.commonmark.test;
+
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.testutil.RenderingTestCase;
+import org.commonmark.testutil.TestResources;
+import org.commonmark.testutil.example.Example;
+import org.commonmark.testutil.example.ExampleReader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class RegressionTest extends RenderingTestCase {
+
+    private static final Parser PARSER = Parser.builder().build();
+    // The spec says URL-escaping is optional, but the examples assume that it's enabled.
+    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().percentEncodeUrls(true).build();
+
+    private final Example example;
+
+    public RegressionTest(Example example) {
+        this.example = example;
+    }
+
+    @Parameters(name = "{0}")
+    public static List<Object[]> data() {
+        List<Object[]> data = new ArrayList<>();
+        for (URL regressionResource : TestResources.getRegressions()) {
+            List<Example> examples = ExampleReader.readExamples(regressionResource);
+            for (Example example : examples) {
+                data.add(new Object[]{example});
+            }
+        }
+        return data;
+    }
+
+    @Test
+    public void testHtmlRendering() {
+        assertRendering(example.getSource(), example.getHtml());
+    }
+
+    @Override
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/test/SpecBenchmark.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecBenchmark.java
@@ -1,8 +1,9 @@
 package org.commonmark.test;
 
-import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.parser.Parser;
-import org.commonmark.testutil.spec.SpecReader;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.testutil.TestResources;
+import org.commonmark.testutil.example.ExampleReader;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -17,8 +18,8 @@ import java.util.List;
 @State(Scope.Benchmark)
 public class SpecBenchmark {
 
-    private static final String SPEC = SpecReader.readSpec();
-    private static final List<String> SPEC_EXAMPLES = SpecReader.readExamplesAsString();
+    private static final String SPEC = TestResources.readAsString(TestResources.getSpec());
+    private static final List<String> SPEC_EXAMPLES = ExampleReader.readExampleSources(TestResources.getSpec());
     private static final Parser PARSER = Parser.builder().build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();
 

--- a/commonmark/src/test/java/org/commonmark/test/SpecCoreTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecCoreTest.java
@@ -6,7 +6,7 @@ import org.commonmark.node.Node;
 import org.commonmark.node.Text;
 import org.commonmark.parser.Parser;
 import org.commonmark.testutil.SpecTestCase;
-import org.commonmark.testutil.spec.SpecExample;
+import org.commonmark.testutil.example.Example;
 import org.junit.Test;
 
 import static org.junit.Assert.fail;
@@ -17,7 +17,7 @@ public class SpecCoreTest extends SpecTestCase {
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().percentEncodeUrls(true).build();
 
-    public SpecCoreTest(SpecExample example) {
+    public SpecCoreTest(Example example) {
         super(example);
     }
 

--- a/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SpecialInputTest.java
@@ -110,9 +110,10 @@ public class SpecialInputTest extends CoreRenderingTestCase {
 
     @Test
     public void linkDestinationEscaping() {
+        // Backslash escapes `)`
         assertRendering("[foo](\\))", "<p><a href=\")\">foo</a></p>\n");
-        assertRendering("[foo](\\ )", "<p><a href=\"\\ \">foo</a></p>\n");
-
+        // ` ` is not escapable, so the backslash is a literal backslash and there's an optional space at the end
+        assertRendering("[foo](\\ )", "<p><a href=\"\\\">foo</a></p>\n");
         // Backslash escapes `>`, so it's not a `(<...>)` link, but a `(...)` link instead
         assertRendering("[foo](<\\>)", "<p><a href=\"&lt;&gt;\">foo</a></p>\n");
         // Backslash is a literal, so valid

--- a/etc/update-spec.sh
+++ b/etc/update-spec.sh
@@ -6,4 +6,8 @@ if [ "$#" -ne 1 ]; then
 fi
 
 version=$1
-curl -L "https://raw.githubusercontent.com/jgm/CommonMark/$version/spec.txt" -o commonmark-test-util/src/main/resources/spec.txt
+curl -L "https://raw.githubusercontent.com/commonmark/CommonMark/$version/spec.txt" -o commonmark-test-util/src/main/resources/spec.txt
+
+echo "Check cmark and commonmark.js regression.txt:"
+echo "https://github.com/commonmark/cmark/blob/master/test/regression.txt"
+echo "https://github.com/commonmark/commonmark.js/blob/master/test/regression.txt"


### PR DESCRIPTION
There were two failing tests, related to:

* Backslash in link destinations (see commonmark/CommonMark#493)
* Tabs in ATX/Setext headers

Change the implementation to match the reference implementation.