### PR TITLE
Replace regex matching in FencedCodeBlockParser

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
@@ -1,18 +1,13 @@
 package org.commonmark.internal;
 
+import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.parser.block.*;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static org.commonmark.internal.util.Escaping.unescapeString;
 
 public class FencedCodeBlockParser extends AbstractBlockParser {
-
-    private static final Pattern OPENING_FENCE = Pattern.compile("^`{3,}(?!.*`)|^~{3,}(?!.*~)");
-    private static final Pattern CLOSING_FENCE = Pattern.compile("^(?:`{3,}|~{3,})(?= *$)");
 
     private final FencedCodeBlock block = new FencedCodeBlock();
 
@@ -35,13 +30,8 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
         int nextNonSpace = state.getNextNonSpaceIndex();
         int newIndex = state.getIndex();
         CharSequence line = state.getLine();
-        Matcher matcher = null;
-        boolean matches = (state.getIndent() <= 3 &&
-                nextNonSpace < line.length() &&
-                line.charAt(nextNonSpace) == block.getFenceChar() &&
-                (matcher = CLOSING_FENCE.matcher(line.subSequence(nextNonSpace, line.length())))
-                        .find());
-        if (matches && matcher.group(0).length() >= block.getFenceLength()) {
+        boolean closing = state.getIndent() < Parsing.CODE_BLOCK_INDENT && isClosing(line, nextNonSpace);
+        if (closing) {
             // closing fence - we're at end of line, so we can finalize now
             return BlockContinue.finished();
         } else {
@@ -76,18 +66,84 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
 
         @Override
         public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
+            int indent = state.getIndent();
+            if (indent >= Parsing.CODE_BLOCK_INDENT) {
+                return BlockStart.none();
+            }
+
             int nextNonSpace = state.getNextNonSpaceIndex();
-            CharSequence line = state.getLine();
-            Matcher matcher;
-            if (state.getIndent() < 4 && (matcher = OPENING_FENCE.matcher(line.subSequence(nextNonSpace, line.length()))).find()) {
-                int fenceLength = matcher.group(0).length();
-                char fenceChar = matcher.group(0).charAt(0);
-                FencedCodeBlockParser blockParser = new FencedCodeBlockParser(fenceChar, fenceLength, state.getIndent());
-                return BlockStart.of(blockParser).atIndex(nextNonSpace + fenceLength);
+            FencedCodeBlockParser blockParser = checkOpener(state.getLine(), nextNonSpace, indent);
+            if (blockParser != null) {
+                return BlockStart.of(blockParser).atIndex(nextNonSpace + blockParser.block.getFenceLength());
             } else {
                 return BlockStart.none();
             }
         }
     }
-}
 
+    // spec: A code fence is a sequence of at least three consecutive backtick characters (`) or tildes (~). (Tildes and
+    // backticks cannot be mixed.)
+    private static FencedCodeBlockParser checkOpener(CharSequence line, int index, int indent) {
+        int backticks = 0;
+        int tildes = 0;
+        loop:
+        for (int i = index; i < line.length(); i++) {
+            switch (line.charAt(i)) {
+                case '`':
+                    backticks++;
+                    break;
+                case '~':
+                    tildes++;
+                    break;
+                default:
+                    break loop;
+            }
+        }
+        if (backticks >= 3 && tildes == 0) {
+            for (int i = index + backticks; i < line.length(); i++) {
+                // spec: The info string may not contain any backtick characters.
+                if (line.charAt(i) == '`') {
+                    return null;
+                }
+            }
+            return new FencedCodeBlockParser('`', backticks, indent);
+        } else if (tildes >= 3 && backticks == 0) {
+            for (int i = index + tildes; i < line.length(); i++) {
+                // This follows commonmark.js but the spec is unclear about this:
+                // https://github.com/commonmark/CommonMark/issues/119
+                if (line.charAt(i) == '~') {
+                    return null;
+                }
+            }
+            return new FencedCodeBlockParser('~', tildes, indent);
+        } else {
+            return null;
+        }
+    }
+
+    // spec: The content of the code block consists of all subsequent lines, until a closing code fence of the same type
+    // as the code block began with (backticks or tildes), and with at least as many backticks or tildes as the opening
+    // code fence.
+    private boolean isClosing(CharSequence line, int index) {
+        char fenceChar = block.getFenceChar();
+        int fenceLength = block.getFenceLength();
+        int fences = 0;
+        for (int i = index; i < line.length(); i++) {
+            if (line.charAt(i) == fenceChar) {
+                fences++;
+            } else {
+                break;
+            }
+        }
+        if (fences < fenceLength) {
+            return false;
+        }
+        // spec: The closing code fence [...] may be followed only by spaces, which are ignored.
+        for (int i = index + fences; i < line.length(); i++) {
+            if (line.charAt(i) != ' ') {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockTest.java
@@ -1,0 +1,55 @@
+package org.commonmark.test;
+
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.testutil.RenderingTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FencedCodeBlockTest extends RenderingTestCase {
+
+    private static final Parser PARSER = Parser.builder().build();
+    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();
+
+    @Test
+    public void backtickInfo() {
+        Node document = PARSER.parse("```info ~ test\ncode\n```");
+        FencedCodeBlock codeBlock = (FencedCodeBlock) document.getFirstChild();
+        assertEquals("info ~ test", codeBlock.getInfo());
+        assertEquals("code\n", codeBlock.getLiteral());
+    }
+
+    @Test
+    public void backtickInfoDoesntAllowBacktick() {
+        assertRendering("```info ` test\ncode\n```",
+                "<p>```info ` test\ncode</p>\n<pre><code></code></pre>\n");
+        // Note, it's unclear in the spec whether a ~~~ code block can contain ` in info or not, see:
+        // https://github.com/commonmark/CommonMark/issues/119
+    }
+
+    @Test
+    public void backtickAndTildeCantBeMixed() {
+        assertRendering("``~`\ncode\n``~`",
+                "<p><code>~` code</code>~`</p>\n");
+    }
+
+    @Test
+    public void closingCanHaveSpacesAfter() {
+        assertRendering("```\ncode\n```   ",
+                "<pre><code>code\n</code></pre>\n");
+    }
+
+    @Test
+    public void closingCanNotHaveNonSpaces() {
+        assertRendering("```\ncode\n``` a",
+                "<pre><code>code\n``` a\n</code></pre>\n");
+    }
+
+    @Override
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+}


### PR DESCRIPTION
The use of Matcher in there showed up showed up in a profiling session
on Android. Using Matcher also means doing more short-lived allocations.

Replace it with some simple looping code. This gives a nice speedup for
the whole spec benchmark (which is a long document with quite a few
fenced code blocks). Before:

    Benchmark                 Mode  Cnt    Score   Error  Units
    SpecBenchmark.wholeSpec  thrpt  200  104.297 ± 1.124  ops/s

After:

    SpecBenchmark.wholeSpec  thrpt  200  124.558 ± 0.485  ops/s