### PR TITLE
Optimize block parsing by replacing regexes

### DIFF
--- a/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/FencedCodeBlockParser.java
@@ -100,20 +100,16 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
             }
         }
         if (backticks >= 3 && tildes == 0) {
-            for (int i = index + backticks; i < line.length(); i++) {
-                // spec: The info string may not contain any backtick characters.
-                if (line.charAt(i) == '`') {
-                    return null;
-                }
+            // spec: The info string may not contain any backtick characters.
+            if (Parsing.find('`', line, index + backticks) != -1) {
+                return null;
             }
             return new FencedCodeBlockParser('`', backticks, indent);
         } else if (tildes >= 3 && backticks == 0) {
-            for (int i = index + tildes; i < line.length(); i++) {
-                // This follows commonmark.js but the spec is unclear about this:
-                // https://github.com/commonmark/CommonMark/issues/119
-                if (line.charAt(i) == '~') {
-                    return null;
-                }
+            // This follows commonmark.js but the spec is unclear about this:
+            // https://github.com/commonmark/CommonMark/issues/119
+            if (Parsing.find('~', line, index + tildes) != -1) {
+                return null;
             }
             return new FencedCodeBlockParser('~', tildes, indent);
         } else {
@@ -127,23 +123,12 @@ public class FencedCodeBlockParser extends AbstractBlockParser {
     private boolean isClosing(CharSequence line, int index) {
         char fenceChar = block.getFenceChar();
         int fenceLength = block.getFenceLength();
-        int fences = 0;
-        for (int i = index; i < line.length(); i++) {
-            if (line.charAt(i) == fenceChar) {
-                fences++;
-            } else {
-                break;
-            }
-        }
+        int fences = Parsing.skip(fenceChar, line, index, line.length()) - index;
         if (fences < fenceLength) {
             return false;
         }
         // spec: The closing code fence [...] may be followed only by spaces, which are ignored.
-        for (int i = index + fences; i < line.length(); i++) {
-            if (line.charAt(i) != ' ') {
-                return false;
-            }
-        }
-        return true;
+        int after = Parsing.skipSpaceTab(line, index + fences, line.length());
+        return after == line.length();
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/HeadingParser.java
@@ -1,18 +1,12 @@
 package org.commonmark.internal;
 
+import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.Block;
 import org.commonmark.node.Heading;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.block.*;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class HeadingParser extends AbstractBlockParser {
-
-    private static Pattern ATX_HEADING = Pattern.compile("^#{1,6}(?:[ \t]+|$)");
-    private static Pattern ATX_TRAILING = Pattern.compile("(^|[ \t]+)#+[ \t]*$");
-    private static Pattern SETEXT_HEADING = Pattern.compile("^(?:=+|-+)[ \t]*$");
 
     private final Heading block = new Heading();
     private final String content;
@@ -42,35 +36,83 @@ public class HeadingParser extends AbstractBlockParser {
 
         @Override
         public BlockStart tryStart(ParserState state, MatchedBlockParser matchedBlockParser) {
-            if (state.getIndent() >= 4) {
+            if (state.getIndent() >= Parsing.CODE_BLOCK_INDENT) {
                 return BlockStart.none();
             }
+
             CharSequence line = state.getLine();
             int nextNonSpace = state.getNextNonSpaceIndex();
-            CharSequence paragraph = matchedBlockParser.getParagraphContent();
-            Matcher matcher;
-            if ((matcher = ATX_HEADING.matcher(line.subSequence(nextNonSpace, line.length()))).find()) {
-                // ATX heading
-                int newOffset = nextNonSpace + matcher.group(0).length();
-                int level = matcher.group(0).trim().length(); // number of #s
-                // remove trailing ###s:
-                CharSequence afterLeading = line.subSequence(newOffset, line.length());
-                String content = ATX_TRAILING.matcher(afterLeading).replaceAll("");
-                return BlockStart.of(new HeadingParser(level, content))
-                        .atIndex(line.length());
-
-            } else if (paragraph != null &&
-                    ((matcher = SETEXT_HEADING.matcher(line.subSequence(nextNonSpace, line.length()))).find())) {
-                // setext heading line
-
-                int level = matcher.group(0).charAt(0) == '=' ? 1 : 2;
-                String content = paragraph.toString();
-                return BlockStart.of(new HeadingParser(level, content))
-                        .atIndex(line.length())
-                        .replaceActiveBlockParser();
-            } else {
-                return BlockStart.none();
+            HeadingParser atxHeading = getAtxHeading(line, nextNonSpace);
+            if (atxHeading != null) {
+                return BlockStart.of(atxHeading).atIndex(line.length());
             }
+
+            int setextHeadingLevel = getSetextHeadingLevel(line, nextNonSpace);
+            if (setextHeadingLevel > 0) {
+                CharSequence paragraph = matchedBlockParser.getParagraphContent();
+                if (paragraph != null) {
+                    String content = paragraph.toString();
+                    return BlockStart.of(new HeadingParser(setextHeadingLevel, content))
+                            .atIndex(line.length())
+                            .replaceActiveBlockParser();
+                }
+            }
+
+            return BlockStart.none();
         }
+    }
+
+    // spec: An ATX heading consists of a string of characters, parsed as inline content, between an opening sequence of
+    // 1–6 unescaped # characters and an optional closing sequence of any number of unescaped # characters. The opening
+    // sequence of # characters must be followed by a space or by the end of line. The optional closing sequence of #s
+    // must be preceded by a space and may be followed by spaces only.
+    private static HeadingParser getAtxHeading(CharSequence line, int index) {
+        int level = Parsing.skip('#', line, index, line.length()) - index;
+
+        if (level == 0 || level > 6) {
+            return null;
+        }
+
+        int start = index + level;
+        if (start >= line.length()) {
+            // End of line after markers is an empty heading
+            return new HeadingParser(level, "");
+        }
+
+        char next = line.charAt(start);
+        if (!(next == ' ' || next == '\t')) {
+            return null;
+        }
+
+        int beforeSpace = Parsing.skipSpaceTabBackwards(line, line.length() - 1, start);
+        int beforeHash = Parsing.skipBackwards('#', line, beforeSpace, start);
+        int beforeTrailer = Parsing.skipSpaceTabBackwards(line, beforeHash, start);
+        if (beforeTrailer != beforeHash) {
+            return new HeadingParser(level, line.subSequence(start, beforeTrailer + 1).toString());
+        } else {
+            return new HeadingParser(level, line.subSequence(start, beforeSpace + 1).toString());
+        }
+    }
+
+    // spec: A setext heading underline is a sequence of = characters or a sequence of - characters, with no more than
+    // 3 spaces indentation and any number of trailing spaces.
+    private static int getSetextHeadingLevel(CharSequence line, int index) {
+        switch (line.charAt(index)) {
+            case '=':
+                if (isSetextHeadingRest(line, index + 1, '=')) {
+                    return 1;
+                }
+            case '-':
+                if (isSetextHeadingRest(line, index + 1, '-')) {
+                    return 2;
+                }
+        }
+        return 0;
+    }
+
+    private static boolean isSetextHeadingRest(CharSequence line, int index, char marker) {
+        int afterMarker = Parsing.skip(marker, line, index, line.length());
+        int afterSpace = Parsing.skipSpaceTab(line, afterMarker, line.length());
+        return afterSpace >= line.length();
     }
 }

--- a/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
@@ -85,6 +85,50 @@ public class Parsing {
         }
     }
 
+    public static int skip(char skip, CharSequence s, int startIndex, int endIndex) {
+        for (int i = startIndex; i < endIndex; i++) {
+            if (s.charAt(i) != skip) {
+                return i;
+            }
+        }
+        return endIndex;
+    }
+
+    public static int skipBackwards(char skip, CharSequence s, int startIndex, int lastIndex) {
+        for (int i = startIndex; i >= lastIndex; i--) {
+            if (s.charAt(i) != skip) {
+                return i;
+            }
+        }
+        return lastIndex - 1;
+    }
+
+    public static int skipSpaceTab(CharSequence s, int startIndex, int endIndex) {
+        for (int i = startIndex; i < endIndex; i++) {
+            switch (s.charAt(i)) {
+                case ' ':
+                case '\t':
+                    break;
+                default:
+                    return i;
+            }
+        }
+        return endIndex;
+    }
+
+    public static int skipSpaceTabBackwards(CharSequence s, int startIndex, int lastIndex) {
+        for (int i = startIndex; i >= lastIndex; i--) {
+            switch (s.charAt(i)) {
+                case ' ':
+                case '\t':
+                    break;
+                default:
+                    return i;
+            }
+        }
+        return lastIndex - 1;
+    }
+
     private static int findNonSpace(CharSequence s, int startIndex) {
         for (int i = startIndex; i < s.length(); i++) {
             switch (s.charAt(i)) {

--- a/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
+++ b/commonmark/src/main/java/org/commonmark/internal/util/Parsing.java
@@ -24,6 +24,15 @@ public class Parsing {
         return 4 - (column % 4);
     }
 
+    public static int find(char c, CharSequence s, int startIndex) {
+        for (int i = startIndex; i < s.length(); i++) {
+            if (s.charAt(i) == c) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public static int findLineBreak(CharSequence s, int startIndex) {
         for (int i = startIndex; i < s.length(); i++) {
             switch (s.charAt(i)) {

--- a/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/FencedCodeBlockParserTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class FencedCodeBlockTest extends RenderingTestCase {
+public class FencedCodeBlockParserTest extends RenderingTestCase {
 
     private static final Parser PARSER = Parser.builder().build();
     private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();

--- a/commonmark/src/test/java/org/commonmark/test/HeadingParserTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/HeadingParserTest.java
@@ -1,0 +1,53 @@
+package org.commonmark.test;
+
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.commonmark.testutil.RenderingTestCase;
+import org.junit.Test;
+
+public class HeadingParserTest extends RenderingTestCase {
+
+    private static final Parser PARSER = Parser.builder().build();
+    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().build();
+
+    @Test
+    public void atxHeadingStart() {
+        assertRendering("# test", "<h1>test</h1>\n");
+        assertRendering("###### test", "<h6>test</h6>\n");
+        assertRendering("####### test", "<p>####### test</p>\n");
+        assertRendering("#test", "<p>#test</p>\n");
+        assertRendering("#", "<h1></h1>\n");
+    }
+
+    @Test
+    public void atxHeadingTrailing() {
+        assertRendering("# test #", "<h1>test</h1>\n");
+        assertRendering("# test ###", "<h1>test</h1>\n");
+        assertRendering("# test # ", "<h1>test</h1>\n");
+        assertRendering("# test  ###  ", "<h1>test</h1>\n");
+        assertRendering("# test # #", "<h1>test #</h1>\n");
+        assertRendering("# test#", "<h1>test#</h1>\n");
+    }
+
+    @Test
+    public void atxHeadingSurrogates() {
+        assertRendering("# \uD83D\uDE0A #", "<h1>\uD83D\uDE0A</h1>\n");
+    }
+
+    @Test
+    public void setextHeadingMarkers() {
+        assertRendering("test\n=", "<h1>test</h1>\n");
+        assertRendering("test\n-", "<h2>test</h2>\n");
+        assertRendering("test\n====", "<h1>test</h1>\n");
+        assertRendering("test\n----", "<h2>test</h2>\n");
+        assertRendering("test\n====   ", "<h1>test</h1>\n");
+        assertRendering("test\n====   =", "<p>test\n====   =</p>\n");
+        assertRendering("test\n=-=", "<p>test\n=-=</p>\n");
+        assertRendering("test\n=a", "<p>test\n=a</p>\n");
+    }
+
+    @Override
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+}


### PR DESCRIPTION
Block parsers use regex matching to check whether a line matches that block. That means for every line, we try a bunch of regexes. These can add up. The use of `Matcher` showed up in a profiling session on Android.

One way to fix that would be to check only one character first, and only if it matches what the block parser expects, run the full regex. But that seems like a bit of a strange mix.

Instead, this PR replaces all the regex use in block parsers with fairly simple looping code.

This gives a nice speedup for the benchmarks. Before:

```
Benchmark                 Mode  Cnt    Score   Error  Units
SpecBenchmark.wholeSpec  thrpt  200  109.766 ± 0.366  ops/s
SpecBenchmark.examples   thrpt  200  257.182 ± 0.789  ops/s
```

After:

```
Benchmark                 Mode  Cnt    Score   Error  Units
SpecBenchmark.wholeSpec  thrpt  200  127.930 ± 0.600  ops/s
SpecBenchmark.examples   thrpt  200  305.566 ± 0.959  ops/s
```

So that's about a 15% to 18% improvement! 🎉

There's probably some potential for improvement in inline parsing as well, but haven't looked at that yet.