### PR TITLE
Add a huge horizontal rule testcase

### DIFF
--- a/commonmark/src/test/java/org/commonmark/test/PathologicalTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/PathologicalTest.java
@@ -99,4 +99,11 @@ public class PathologicalTest extends CoreRenderingTestCase {
                 repeat("<blockquote>\n", x) + "<p>a</p>\n" +
                         repeat("</blockquote>\n", x));
     }
+
+    @Test
+    public void hugeHorizontalRule() {
+        assertRendering(
+                repeat("*", 10000) + "\n",
+                "<hr />\n");
+    }
 }


### PR DESCRIPTION
In version 0.11.0 a huge horizontal rule of thousands of characters caused a stack overflow error. In 0.12.0 that was fixed in commit ad397cb79 when ThematicBreakParser.isThematicBreak() was modified to
avoid using a regex.

This regression test fails on 0.11.0 and passes on 0.12.0 and later. With a default stack size (default for my system at least) the test starts failing somewhere between 1000 and 2000 characters. This was reported initially against Bitbucket Server, where some string that I can only imagine wasn't intended to be a real markdown horizontal rule was being parsed as such. See: https://jira.atlassian.com/browse/BSERV-11497