### PR TITLE
Add ability to render into something other than string

### DIFF
--- a/commonmark/src/main/java/org/commonmark/renderer/Renderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/Renderer.java
@@ -2,7 +2,7 @@ package org.commonmark.renderer;
 
 import org.commonmark.node.Node;
 
-public interface Renderer {
+public interface Renderer<Output, Render> {
 
     /**
      * Render the tree of nodes to output.
@@ -10,13 +10,13 @@ public interface Renderer {
      * @param node the root node
      * @param output output for rendering
      */
-    void render(Node node, Appendable output);
+    void render(Node node, Output output);
 
     /**
      * Render the tree of nodes to string.
      *
      * @param node the root node
-     * @return the rendered string
+     * @return the rendered render
      */
-    String render(Node node);
+    Render render(Node node);
 }

--- a/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/html/HtmlRenderer.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * renderer.render(node);
  * </code></pre>
  */
-public class HtmlRenderer implements Renderer {
+public class HtmlRenderer implements Renderer<Appendable, String> {
 
     private final String softbreak;
     private final boolean escapeHtml;

--- a/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
+++ b/commonmark/src/main/java/org/commonmark/renderer/text/TextContentRenderer.java
@@ -9,7 +9,7 @@ import org.commonmark.renderer.Renderer;
 import java.util.ArrayList;
 import java.util.List;
 
-public class TextContentRenderer implements Renderer {
+public class TextContentRenderer implements Renderer<Appendable, String> {
 
     private final boolean stripNewlines;
 


### PR DESCRIPTION
Hi =)

I'm making [extensions](https://github.com/OlegKrikun/commonmark-kotlinx-html) that rendering document into [kotlinx.html](https://github.com/Kotlin/kotlinx.html) stream, but `Renderer` interface accept only `Appendable`/`String` as result type.

This PR add ability to render into something other than string.