### PR TITLE
Adding a link to the README header and diagrams to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,14 @@ existing issues with label "help wanted".
 For bigger changes, make sure you start a discussion first by creating
 an issue and explaining the intended change.
 
+The [sourcespy dashboard](https://sourcespy.com/github/atlassiancommonmarkjava/)
+provides a high level overview of the repository including
+[class diagram](https://sourcespy.com/github/atlassiancommonmarkjava/xx-omodel-.html),
+[module dependencies](https://sourcespy.com/github/atlassiancommonmarkjava/xx-omodulesc-.html),
+[module hierarchy](https://sourcespy.com/github/atlassiancommonmarkjava/xx-omodules-.html),
+[external libraries](https://sourcespy.com/github/atlassiancommonmarkjava/xx-ojavalibs-.html),
+and other components of the system.
+
 CLA
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Java library for parsing and rendering [Markdown] text according to the
 [![javadoc](https://www.javadoc.io/badge/com.atlassian.commonmark/commonmark.svg?color=blue)](https://www.javadoc.io/doc/com.atlassian.commonmark/commonmark)
 [![Build status](https://travis-ci.org/atlassian/commonmark-java.svg?branch=master)](https://travis-ci.org/atlassian/commonmark-java)
 [![codecov](https://codecov.io/gh/atlassian/commonmark-java/branch/master/graph/badge.svg)](https://codecov.io/gh/atlassian/commonmark-java)
+[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/atlassiancommonmarkjava/)
 
 Introduction
 ------------
@@ -370,7 +371,7 @@ See also
 Contributing
 ------------
 
-See CONTRIBUTING.md file.
+See [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 License
 -------


### PR DESCRIPTION
Fixed link to CONTRIBUTING.md and linked dashboard that describes overall repository structure. The goal is to help new developers explore project and understand architecture/dependencies. Direct link: https://www.sourcespy.com/github/atlassiancommonmarkjava/