### PR TITLE
Image attributes extension is not expected to alter unrelated text nodes

### DIFF
--- a/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
+++ b/commonmark-ext-image-attributes/src/main/java/org/commonmark/ext/image/attributes/internal/ImageAttributesDelimiterProcessor.java
@@ -95,6 +95,6 @@ public class ImageAttributesDelimiterProcessor implements DelimiterProcessor {
         } else {
             opener.getPrevious().insertAfter(new Text("" + getOpeningCharacter()));
         }
-        closer.getParent().appendChild(new Text("" + getClosingCharacter()));
+        closer.insertAfter(new Text("" + getClosingCharacter()));
     }
 }

--- a/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
+++ b/commonmark-ext-image-attributes/src/test/java/org/commonmark/ext/image/attributes/ImageAttributesTest.java
@@ -109,6 +109,8 @@ public class ImageAttributesTest extends RenderingTestCase {
         assertRendering("x {height=3 width=4}\n", "<p>x {height=3 width=4}</p>\n");
         assertRendering("\\documentclass[12pt]{article}\n", "<p>\\documentclass[12pt]{article}</p>\n");
         assertRendering("some *text*{height=3 width=4}\n", "<p>some <em>text</em>{height=3 width=4}</p>\n");
+        assertRendering("{NN} text", "<p>{NN} text</p>\n");
+        assertRendering("{}", "<p>{}</p>\n");
     }
 
     @Override


### PR DESCRIPTION
A small fix to prevent the following rendering issue when using ImageAttributesExtension:
```
{NN} text -> {NN text}
```