### PR TITLE
Support for including source spans on block nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html),
 with the exception that 0.x versions can break between minor versions.
 
+## Unreleased
+### Added
+- Support for including source spans on block nodes:
+  - Answer for "Where in the source input (line/column position and length) does this block come from?"
+  - Useful for things like editors that want to keep the input and rendered output scrolled to the same lines,
+    or start editing on the block that was selected.
+  - Use `includeSourceSpans` on `Parser.Builder` to enable, read data with `Node.getSourceSpans`
+
 ## [0.15.2] - 2020-07-20
 ### Fixed
 - image-attributes extension: Fix unexpected altering of text in case

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
@@ -83,7 +83,7 @@ public class TableBlockParser extends AbstractBlockParser {
         // Body starts at index 2. 0 is header, 1 is separator.
         for (int rowIndex = 2; rowIndex < rowLines.size(); rowIndex++) {
             CharSequence rowLine = rowLines.get(rowIndex);
-            SourceSpan sourceSpan = sourceSpans.get(rowIndex);
+            SourceSpan sourceSpan = rowIndex < sourceSpans.size() ? sourceSpans.get(rowIndex) : null;
             List<CellSource> cells = split(rowLine, sourceSpan);
             TableRow row = new TableRow();
             row.addSourceSpan(sourceSpan);

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
@@ -1,26 +1,34 @@
 package org.commonmark.ext.gfm.tables.internal;
 
-import org.commonmark.ext.gfm.tables.*;
+import org.commonmark.ext.gfm.tables.TableBlock;
+import org.commonmark.ext.gfm.tables.TableBody;
+import org.commonmark.ext.gfm.tables.TableCell;
+import org.commonmark.ext.gfm.tables.TableHead;
+import org.commonmark.ext.gfm.tables.TableRow;
 import org.commonmark.node.Block;
 import org.commonmark.node.Node;
+import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.InlineParser;
-import org.commonmark.parser.block.*;
+import org.commonmark.parser.block.AbstractBlockParser;
+import org.commonmark.parser.block.AbstractBlockParserFactory;
+import org.commonmark.parser.block.BlockContinue;
+import org.commonmark.parser.block.BlockStart;
+import org.commonmark.parser.block.MatchedBlockParser;
+import org.commonmark.parser.block.ParserState;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TableBlockParser extends AbstractBlockParser {
 
     private final TableBlock block = new TableBlock();
-    private final List<CharSequence> bodyLines = new ArrayList<>();
+    private final List<CharSequence> rowLines = new ArrayList<>();
     private final List<TableCell.Alignment> columns;
-    private final List<String> headerCells;
 
-    private boolean nextIsSeparatorLine = true;
-
-    private TableBlockParser(List<TableCell.Alignment> columns, List<String> headerCells) {
+    private TableBlockParser(List<TableCell.Alignment> columns, CharSequence headerLine) {
         this.columns = columns;
-        this.headerCells = headerCells;
+        this.rowLines.add(headerLine);
     }
 
     @Override
@@ -44,37 +52,45 @@ public class TableBlockParser extends AbstractBlockParser {
 
     @Override
     public void addLine(CharSequence line) {
-        if (nextIsSeparatorLine) {
-            nextIsSeparatorLine = false;
-        } else {
-            bodyLines.add(line);
-        }
+        rowLines.add(line);
     }
 
     @Override
     public void parseInlines(InlineParser inlineParser) {
-        int headerColumns = headerCells.size();
+        List<SourceSpan> sourceSpans = block.getSourceSpans();
 
+        SourceSpan headerSourceSpan = !sourceSpans.isEmpty() ? sourceSpans.get(0) : null;
         Node head = new TableHead();
+        if (headerSourceSpan != null) {
+            head.getSourceSpans().add(headerSourceSpan);
+        }
         block.appendChild(head);
 
         TableRow headerRow = new TableRow();
+        headerRow.setSourceSpans(head.getSourceSpans());
         head.appendChild(headerRow);
+
+        List<CellSource> headerCells = split(rowLines.get(0), headerSourceSpan);
+        int headerColumns = headerCells.size();
         for (int i = 0; i < headerColumns; i++) {
-            String cell = headerCells.get(i);
+            CellSource cell = headerCells.get(i);
             TableCell tableCell = parseCell(cell, i, inlineParser);
             tableCell.setHeader(true);
             headerRow.appendChild(tableCell);
         }
 
-        Node body = null;
-        for (CharSequence rowLine : bodyLines) {
-            List<String> cells = split(rowLine);
+        TableBody body = null;
+        // Body starts at index 2. 0 is header, 1 is separator.
+        for (int rowIndex = 2; rowIndex < rowLines.size(); rowIndex++) {
+            CharSequence rowLine = rowLines.get(rowIndex);
+            SourceSpan sourceSpan = sourceSpans.get(rowIndex);
+            List<CellSource> cells = split(rowLine, sourceSpan);
             TableRow row = new TableRow();
+            row.getSourceSpans().add(sourceSpan);
 
             // Body can not have more columns than head
             for (int i = 0; i < headerColumns; i++) {
-                String cell = i < cells.size() ? cells.get(i) : "";
+                CellSource cell = i < cells.size() ? cells.get(i) : new CellSource("", null);
                 TableCell tableCell = parseCell(cell, i, inlineParser);
                 row.appendChild(tableCell);
             }
@@ -85,33 +101,35 @@ public class TableBlockParser extends AbstractBlockParser {
                 block.appendChild(body);
             }
             body.appendChild(row);
+            body.getSourceSpans().add(sourceSpan);
         }
     }
 
-    private TableCell parseCell(String cell, int column, InlineParser inlineParser) {
+    private TableCell parseCell(CellSource cell, int column, InlineParser inlineParser) {
         TableCell tableCell = new TableCell();
 
         if (column < columns.size()) {
             tableCell.setAlignment(columns.get(column));
         }
 
-        inlineParser.parse(cell.trim(), tableCell);
+        if (cell.sourceSpan != null) {
+            tableCell.setSourceSpans(Collections.singletonList(cell.sourceSpan));
+        }
+
+        inlineParser.parse(cell.content, tableCell);
 
         return tableCell;
     }
 
-    private static List<String> split(CharSequence input) {
-        String line = input.toString().trim();
-        if (line.startsWith("|")) {
-            line = line.substring(1);
-        }
-        List<String> cells = new ArrayList<>();
+    private static List<CellSource> split(CharSequence row, SourceSpan rowSourceSpan) {
+        int cellStart = row.charAt(0) == '|' ? 1 : 0;
+        List<CellSource> cells = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < line.length(); i++) {
-            char c = line.charAt(i);
+        for (int i = cellStart; i < row.length(); i++) {
+            char c = row.charAt(i);
             switch (c) {
                 case '\\':
-                    if (i + 1 < line.length() && line.charAt(i + 1) == '|') {
+                    if (i + 1 < row.length() && row.charAt(i + 1) == '|') {
                         // Pipe is special for table parsing. An escaped pipe doesn't result in a new cell, but is
                         // passed down to inline parsing as an unescaped pipe. Note that that applies even for the `\|`
                         // in an input like `\\|` - in other words, table parsing doesn't support escaping backslashes.
@@ -123,15 +141,19 @@ public class TableBlockParser extends AbstractBlockParser {
                     }
                     break;
                 case '|':
-                    cells.add(sb.toString());
+                    String content = sb.toString();
+                    cells.add(CellSource.of(content, rowSourceSpan, cellStart));
                     sb.setLength(0);
+                    // + 1 to skip the pipe itself for the next cell's span
+                    cellStart = i + 1;
                     break;
                 default:
                     sb.append(c);
             }
         }
         if (sb.length() > 0) {
-            cells.add(sb.toString());
+            String content = sb.toString();
+            cells.add(CellSource.of(content, rowSourceSpan, cellStart));
         }
         return cells;
     }
@@ -229,9 +251,9 @@ public class TableBlockParser extends AbstractBlockParser {
                 CharSequence separatorLine = line.subSequence(state.getIndex(), line.length());
                 List<TableCell.Alignment> columns = parseSeparator(separatorLine);
                 if (columns != null && !columns.isEmpty()) {
-                    List<String> headerCells = split(paragraph);
+                    List<CellSource> headerCells = split(paragraph, null);
                     if (columns.size() >= headerCells.size()) {
-                        return BlockStart.of(new TableBlockParser(columns, headerCells))
+                        return BlockStart.of(new TableBlockParser(columns, paragraph))
                                 .atIndex(state.getIndex())
                                 .replaceActiveBlockParser();
                     }
@@ -241,4 +263,26 @@ public class TableBlockParser extends AbstractBlockParser {
         }
     }
 
+    private static class CellSource {
+
+        private final String content;
+        private final SourceSpan sourceSpan;
+
+        public static CellSource of(String content, SourceSpan rowSourceSpan, int offset) {
+            if (!content.isEmpty()) {
+                SourceSpan sourceSpan = null;
+                if (rowSourceSpan != null) {
+                    sourceSpan = SourceSpan.of(rowSourceSpan.getLineIndex(), rowSourceSpan.getColumnIndex() + offset, content.length());
+                }
+                return new CellSource(content, sourceSpan);
+            } else {
+                return new CellSource(content, null);
+            }
+        }
+
+        private CellSource(String content, SourceSpan sourceSpan) {
+            this.content = content;
+            this.sourceSpan = sourceSpan;
+        }
+    }
 }

--- a/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
+++ b/commonmark-ext-gfm-tables/src/main/java/org/commonmark/ext/gfm/tables/internal/TableBlockParser.java
@@ -62,7 +62,7 @@ public class TableBlockParser extends AbstractBlockParser {
         SourceSpan headerSourceSpan = !sourceSpans.isEmpty() ? sourceSpans.get(0) : null;
         Node head = new TableHead();
         if (headerSourceSpan != null) {
-            head.getSourceSpans().add(headerSourceSpan);
+            head.addSourceSpan(headerSourceSpan);
         }
         block.appendChild(head);
 
@@ -86,7 +86,7 @@ public class TableBlockParser extends AbstractBlockParser {
             SourceSpan sourceSpan = sourceSpans.get(rowIndex);
             List<CellSource> cells = split(rowLine, sourceSpan);
             TableRow row = new TableRow();
-            row.getSourceSpans().add(sourceSpan);
+            row.addSourceSpan(sourceSpan);
 
             // Body can not have more columns than head
             for (int i = 0; i < headerColumns; i++) {
@@ -101,7 +101,7 @@ public class TableBlockParser extends AbstractBlockParser {
                 block.appendChild(body);
             }
             body.appendChild(row);
-            body.getSourceSpans().add(sourceSpan);
+            body.addSourceSpan(sourceSpan);
         }
     }
 

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -4,6 +4,7 @@ import org.commonmark.Extension;
 import org.commonmark.node.Node;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.Parser;
+import org.commonmark.parser.IncludeSourceSpans;
 import org.commonmark.renderer.html.AttributeProvider;
 import org.commonmark.renderer.html.AttributeProviderContext;
 import org.commonmark.renderer.html.AttributeProviderFactory;
@@ -648,7 +649,11 @@ public class TablesTest extends RenderingTestCase {
 
     @Test
     public void sourceSpans() {
-        Node document = PARSER.parse("Abc|Def\n---|---\n|1|2\n 3|four|\n|||\n");
+        Parser parser = Parser.builder()
+                .extensions(EXTENSIONS)
+                .includeSourceSpans(IncludeSourceSpans.BLOCKS)
+                .build();
+        Node document = parser.parse("Abc|Def\n---|---\n|1|2\n 3|four|\n|||\n");
 
         TableBlock block = (TableBlock) document.getFirstChild();
         assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -11,13 +11,13 @@ import org.commonmark.renderer.html.HtmlRenderer;
 import org.commonmark.testutil.RenderingTestCase;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.emptyIterable;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class TablesTest extends RenderingTestCase {
@@ -651,42 +651,43 @@ public class TablesTest extends RenderingTestCase {
         Node document = PARSER.parse("Abc|Def\n---|---\n|1|2\n 3|four|\n|||\n");
 
         TableBlock block = (TableBlock) document.getFirstChild();
-        assertThat(block.getSourceSpans(), contains(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),
-                SourceSpan.of(2, 0, 4), SourceSpan.of(3, 1, 7), SourceSpan.of(4, 0, 3)));
+        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),
+                SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)),
+                block.getSourceSpans());
 
         TableHead head = (TableHead) block.getFirstChild();
-        assertThat(head.getSourceSpans(), contains(SourceSpan.of(0, 0, 7)));
+        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7)), head.getSourceSpans());
 
         TableRow headRow = (TableRow) head.getFirstChild();
-        assertThat(headRow.getSourceSpans(), contains(SourceSpan.of(0, 0, 7)));
+        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 7)), headRow.getSourceSpans());
         TableCell headRowCell1 = (TableCell) headRow.getFirstChild();
         TableCell headRowCell2 = (TableCell) headRow.getLastChild();
-        assertThat(headRowCell1.getSourceSpans(), contains(SourceSpan.of(0, 0, 3)));
-        assertThat(headRowCell2.getSourceSpans(), contains(SourceSpan.of(0, 4, 3)));
+        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 3)), headRowCell1.getSourceSpans());
+        assertEquals(Arrays.asList(SourceSpan.of(0, 4, 3)), headRowCell2.getSourceSpans());
 
         TableBody body = (TableBody) block.getLastChild();
-        assertThat(body.getSourceSpans(), contains(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 1, 7), SourceSpan.of(4, 0, 3)));
+        assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 1, 7), SourceSpan.of(4, 0, 3)), body.getSourceSpans());
 
         TableRow bodyRow1 = (TableRow) body.getFirstChild();
-        assertThat(bodyRow1.getSourceSpans(), contains(SourceSpan.of(2, 0, 4)));
+        assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4)), bodyRow1.getSourceSpans());
         TableCell bodyRow1Cell1 = (TableCell) bodyRow1.getFirstChild();
         TableCell bodyRow1Cell2 = (TableCell) bodyRow1.getLastChild();
-        assertThat(bodyRow1Cell1.getSourceSpans(), contains(SourceSpan.of(2, 1, 1)));
-        assertThat(bodyRow1Cell2.getSourceSpans(), contains(SourceSpan.of(2, 3, 1)));
+        assertEquals(Arrays.asList(SourceSpan.of(2, 1, 1)), bodyRow1Cell1.getSourceSpans());
+        assertEquals(Arrays.asList(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getSourceSpans());
 
         TableRow bodyRow2 = (TableRow) body.getFirstChild().getNext();
-        assertThat(bodyRow2.getSourceSpans(), contains(SourceSpan.of(3, 1, 7)));
+        assertEquals(Arrays.asList(SourceSpan.of(3, 1, 7)), bodyRow2.getSourceSpans());
         TableCell bodyRow2Cell1 = (TableCell) bodyRow2.getFirstChild();
         TableCell bodyRow2Cell2 = (TableCell) bodyRow2.getLastChild();
-        assertThat(bodyRow2Cell1.getSourceSpans(), contains(SourceSpan.of(3, 1, 1)));
-        assertThat(bodyRow2Cell2.getSourceSpans(), contains(SourceSpan.of(3, 3, 4)));
+        assertEquals(Arrays.asList(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getSourceSpans());
+        assertEquals(Arrays.asList(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getSourceSpans());
 
         TableRow bodyRow3 = (TableRow) body.getLastChild();
-        assertThat(bodyRow3.getSourceSpans(), contains(SourceSpan.of(4, 0, 3)));
+        assertEquals(Arrays.asList(SourceSpan.of(4, 0, 3)), bodyRow3.getSourceSpans());
         TableCell bodyRow3Cell1 = (TableCell) bodyRow3.getFirstChild();
         TableCell bodyRow3Cell2 = (TableCell) bodyRow3.getLastChild();
-        assertThat(bodyRow3Cell1.getSourceSpans(), emptyIterable());
-        assertThat(bodyRow3Cell2.getSourceSpans(), emptyIterable());
+        assertEquals(Collections.emptyList(), bodyRow3Cell1.getSourceSpans());
+        assertEquals(Collections.emptyList(), bodyRow3Cell2.getSourceSpans());
     }
 
     @Override

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -2,6 +2,7 @@ package org.commonmark.ext.gfm.tables;
 
 import org.commonmark.Extension;
 import org.commonmark.node.Node;
+import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.AttributeProvider;
 import org.commonmark.renderer.html.AttributeProviderContext;
@@ -15,6 +16,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.junit.Assert.assertThat;
 
 public class TablesTest extends RenderingTestCase {
@@ -641,6 +644,49 @@ public class TablesTest extends RenderingTestCase {
                 "</tr>\n" +
                 "</tbody>\n" +
                 "</table>\n"));
+    }
+
+    @Test
+    public void sourceSpans() {
+        Node document = PARSER.parse("Abc|Def\n---|---\n|1|2\n 3|four|\n|||\n");
+
+        TableBlock block = (TableBlock) document.getFirstChild();
+        assertThat(block.getSourceSpans(), contains(SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 7),
+                SourceSpan.of(2, 0, 4), SourceSpan.of(3, 1, 7), SourceSpan.of(4, 0, 3)));
+
+        TableHead head = (TableHead) block.getFirstChild();
+        assertThat(head.getSourceSpans(), contains(SourceSpan.of(0, 0, 7)));
+
+        TableRow headRow = (TableRow) head.getFirstChild();
+        assertThat(headRow.getSourceSpans(), contains(SourceSpan.of(0, 0, 7)));
+        TableCell headRowCell1 = (TableCell) headRow.getFirstChild();
+        TableCell headRowCell2 = (TableCell) headRow.getLastChild();
+        assertThat(headRowCell1.getSourceSpans(), contains(SourceSpan.of(0, 0, 3)));
+        assertThat(headRowCell2.getSourceSpans(), contains(SourceSpan.of(0, 4, 3)));
+
+        TableBody body = (TableBody) block.getLastChild();
+        assertThat(body.getSourceSpans(), contains(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 1, 7), SourceSpan.of(4, 0, 3)));
+
+        TableRow bodyRow1 = (TableRow) body.getFirstChild();
+        assertThat(bodyRow1.getSourceSpans(), contains(SourceSpan.of(2, 0, 4)));
+        TableCell bodyRow1Cell1 = (TableCell) bodyRow1.getFirstChild();
+        TableCell bodyRow1Cell2 = (TableCell) bodyRow1.getLastChild();
+        assertThat(bodyRow1Cell1.getSourceSpans(), contains(SourceSpan.of(2, 1, 1)));
+        assertThat(bodyRow1Cell2.getSourceSpans(), contains(SourceSpan.of(2, 3, 1)));
+
+        TableRow bodyRow2 = (TableRow) body.getFirstChild().getNext();
+        assertThat(bodyRow2.getSourceSpans(), contains(SourceSpan.of(3, 1, 7)));
+        TableCell bodyRow2Cell1 = (TableCell) bodyRow2.getFirstChild();
+        TableCell bodyRow2Cell2 = (TableCell) bodyRow2.getLastChild();
+        assertThat(bodyRow2Cell1.getSourceSpans(), contains(SourceSpan.of(3, 1, 1)));
+        assertThat(bodyRow2Cell2.getSourceSpans(), contains(SourceSpan.of(3, 3, 4)));
+
+        TableRow bodyRow3 = (TableRow) body.getLastChild();
+        assertThat(bodyRow3.getSourceSpans(), contains(SourceSpan.of(4, 0, 3)));
+        TableCell bodyRow3Cell1 = (TableCell) bodyRow3.getFirstChild();
+        TableCell bodyRow3Cell2 = (TableCell) bodyRow3.getLastChild();
+        assertThat(bodyRow3Cell1.getSourceSpans(), emptyIterable());
+        assertThat(bodyRow3Cell2.getSourceSpans(), emptyIterable());
     }
 
     @Override

--- a/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
+++ b/commonmark-ext-gfm-tables/src/test/java/org/commonmark/ext/gfm/tables/TablesTest.java
@@ -666,7 +666,7 @@ public class TablesTest extends RenderingTestCase {
         assertEquals(Arrays.asList(SourceSpan.of(0, 4, 3)), headRowCell2.getSourceSpans());
 
         TableBody body = (TableBody) block.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 1, 7), SourceSpan.of(4, 0, 3)), body.getSourceSpans());
+        assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4), SourceSpan.of(3, 0, 8), SourceSpan.of(4, 0, 3)), body.getSourceSpans());
 
         TableRow bodyRow1 = (TableRow) body.getFirstChild();
         assertEquals(Arrays.asList(SourceSpan.of(2, 0, 4)), bodyRow1.getSourceSpans());
@@ -676,10 +676,10 @@ public class TablesTest extends RenderingTestCase {
         assertEquals(Arrays.asList(SourceSpan.of(2, 3, 1)), bodyRow1Cell2.getSourceSpans());
 
         TableRow bodyRow2 = (TableRow) body.getFirstChild().getNext();
-        assertEquals(Arrays.asList(SourceSpan.of(3, 1, 7)), bodyRow2.getSourceSpans());
+        assertEquals(Arrays.asList(SourceSpan.of(3, 0, 8)), bodyRow2.getSourceSpans());
         TableCell bodyRow2Cell1 = (TableCell) bodyRow2.getFirstChild();
         TableCell bodyRow2Cell2 = (TableCell) bodyRow2.getLastChild();
-        assertEquals(Arrays.asList(SourceSpan.of(3, 1, 1)), bodyRow2Cell1.getSourceSpans());
+        assertEquals(Arrays.asList(SourceSpan.of(3, 0, 2)), bodyRow2Cell1.getSourceSpans());
         assertEquals(Arrays.asList(SourceSpan.of(3, 3, 4)), bodyRow2Cell2.getSourceSpans());
 
         TableRow bodyRow3 = (TableRow) body.getLastChild();

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SourceSpanIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SourceSpanIntegrationTest.java
@@ -1,0 +1,25 @@
+package org.commonmark.integration;
+
+import org.commonmark.parser.IncludeSourceSpans;
+import org.commonmark.parser.Parser;
+import org.commonmark.testutil.example.Example;
+
+/**
+ * Spec and all extensions, with source spans enabed.
+ */
+public class SourceSpanIntegrationTest extends SpecIntegrationTest {
+
+    protected static final Parser PARSER = Parser.builder()
+            .extensions(EXTENSIONS)
+            .includeSourceSpans(IncludeSourceSpans.BLOCKS)
+            .build();
+
+    public SourceSpanIntegrationTest(Example example) {
+        super(example);
+    }
+
+    @Override
+    protected String render(String source) {
+        return RENDERER.render(PARSER.parse(source));
+    }
+}

--- a/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
+++ b/commonmark-integration-test/src/test/java/org/commonmark/integration/SpecIntegrationTest.java
@@ -21,7 +21,7 @@ import java.util.*;
  */
 public class SpecIntegrationTest extends SpecTestCase {
 
-    private static final List<Extension> EXTENSIONS = Arrays.asList(
+    protected static final List<Extension> EXTENSIONS = Arrays.asList(
             AutolinkExtension.create(),
             ImageAttributesExtension.create(),
             InsExtension.create(),
@@ -29,10 +29,10 @@ public class SpecIntegrationTest extends SpecTestCase {
             TablesExtension.create(),
             TaskListItemsExtension.create(),
             YamlFrontMatterExtension.create());
-    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+    protected static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
     // The spec says URL-escaping is optional, but the examples assume that it's enabled.
-    private static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).percentEncodeUrls(true).build();
-    private static final Map<String, String> OVERRIDDEN_EXAMPLES = getOverriddenExamples();
+    protected static final HtmlRenderer RENDERER = HtmlRenderer.builder().extensions(EXTENSIONS).percentEncodeUrls(true).build();
+    protected static final Map<String, String> OVERRIDDEN_EXAMPLES = getOverriddenExamples();
 
     public SpecIntegrationTest(Example example) {
         super(example);

--- a/commonmark-test-util/pom.xml
+++ b/commonmark-test-util/pom.xml
@@ -16,6 +16,10 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/commonmark-test-util/pom.xml
+++ b/commonmark-test-util/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.atlassian.commonmark</groupId>
@@ -15,10 +16,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
         </dependency>
     </dependencies>
 

--- a/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/LinkReferenceDefinitionParser.java
@@ -4,6 +4,7 @@ import org.commonmark.internal.util.Escaping;
 import org.commonmark.internal.util.LinkScanner;
 import org.commonmark.internal.util.Parsing;
 import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.node.SourceSpan;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ public class LinkReferenceDefinitionParser {
 
     private final StringBuilder paragraph = new StringBuilder();
     private final List<LinkReferenceDefinition> definitions = new ArrayList<>();
+    private final List<SourceSpan> sourceSpans = new ArrayList<>();
 
     private StringBuilder label;
     private String normalizedLabel;
@@ -70,8 +72,16 @@ public class LinkReferenceDefinitionParser {
         }
     }
 
+    public void addSourceSpan(SourceSpan sourceSpan) {
+        sourceSpans.add(sourceSpan);
+    }
+
     CharSequence getParagraphContent() {
         return paragraph;
+    }
+
+    List<SourceSpan> getParagraphSourceSpans() {
+        return sourceSpans;
     }
 
     List<LinkReferenceDefinition> getDefinitions() {
@@ -235,7 +245,10 @@ public class LinkReferenceDefinitionParser {
 
         String d = Escaping.unescapeString(destination);
         String t = title != null ? Escaping.unescapeString(title.toString()) : null;
-        definitions.add(new LinkReferenceDefinition(normalizedLabel, d, t));
+        LinkReferenceDefinition definition = new LinkReferenceDefinition(normalizedLabel, d, t);
+        definition.setSourceSpans(sourceSpans);
+        sourceSpans.clear();
+        definitions.add(definition);
 
         label = null;
         referenceValid = false;

--- a/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
@@ -3,6 +3,7 @@ package org.commonmark.internal;
 import org.commonmark.node.Block;
 import org.commonmark.node.LinkReferenceDefinition;
 import org.commonmark.node.Paragraph;
+import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.InlineParser;
 import org.commonmark.parser.block.AbstractBlockParser;
 import org.commonmark.parser.block.BlockContinue;
@@ -13,7 +14,7 @@ import java.util.List;
 public class ParagraphParser extends AbstractBlockParser {
 
     private final Paragraph block = new Paragraph();
-    private LinkReferenceDefinitionParser linkReferenceDefinitionParser = new LinkReferenceDefinitionParser();
+    private final LinkReferenceDefinitionParser linkReferenceDefinitionParser = new LinkReferenceDefinitionParser();
 
     @Override
     public boolean canHaveLazyContinuationLines() {
@@ -40,9 +41,18 @@ public class ParagraphParser extends AbstractBlockParser {
     }
 
     @Override
+    public void addSourceSpan(SourceSpan sourceSpan) {
+        // Some source spans might belong to link reference definitions, others to the paragraph.
+        // The parser will handle that.
+        linkReferenceDefinitionParser.addSourceSpan(sourceSpan);
+    }
+
+    @Override
     public void closeBlock() {
         if (linkReferenceDefinitionParser.getParagraphContent().length() == 0) {
             block.unlink();
+        } else {
+            block.getSourceSpans().addAll(linkReferenceDefinitionParser.getParagraphSourceSpans());
         }
     }
 

--- a/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
+++ b/commonmark/src/main/java/org/commonmark/internal/ParagraphParser.java
@@ -52,7 +52,7 @@ public class ParagraphParser extends AbstractBlockParser {
         if (linkReferenceDefinitionParser.getParagraphContent().length() == 0) {
             block.unlink();
         } else {
-            block.getSourceSpans().addAll(linkReferenceDefinitionParser.getParagraphSourceSpans());
+            block.setSourceSpans(linkReferenceDefinitionParser.getParagraphSourceSpans());
         }
     }
 

--- a/commonmark/src/main/java/org/commonmark/internal/SourceSpans.java
+++ b/commonmark/src/main/java/org/commonmark/internal/SourceSpans.java
@@ -1,0 +1,13 @@
+package org.commonmark.internal;
+
+import org.commonmark.node.SourceSpan;
+import org.commonmark.parser.block.ParserState;
+
+public class SourceSpans {
+
+    public static SourceSpan fromState(ParserState parserState, int startIndex) {
+//        int length = parserState.getLine().length();
+//        return SourceSpan.of(parserState.getLineIndex(), startIndex, length - startIndex);
+        return null;
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/node/Block.java
+++ b/commonmark/src/main/java/org/commonmark/node/Block.java
@@ -1,5 +1,8 @@
 package org.commonmark.node;
 
+/**
+ * Block nodes such as paragraphs, list blocks, code blocks etc.
+ */
 public abstract class Block extends Node {
 
     public Block getParent() {

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -1,5 +1,9 @@
 package org.commonmark.node;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public abstract class Node {
 
     private Node parent = null;
@@ -7,6 +11,7 @@ public abstract class Node {
     private Node lastChild = null;
     private Node prev = null;
     private Node next = null;
+    private List<SourceSpan> sourceSpans = new ArrayList<>();
 
     public abstract void accept(Visitor visitor);
 
@@ -28,6 +33,14 @@ public abstract class Node {
 
     public Node getParent() {
         return parent;
+    }
+
+    public List<SourceSpan> getSourceSpans() {
+        return Collections.unmodifiableList(sourceSpans);
+    }
+
+    public void setSourceSpans(List<SourceSpan> sourceSpans) {
+        this.sourceSpans = new ArrayList<>(sourceSpans);
     }
 
     protected void setParent(Node parent) {

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -4,6 +4,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * The base class of all CommonMark AST nodes ({@link Block} and inlines).
+ * <p>
+ * A node can have multiple children, and a parent (except for the root node).
+ */
 public abstract class Node {
 
     private Node parent = null;
@@ -11,7 +16,7 @@ public abstract class Node {
     private Node lastChild = null;
     private Node prev = null;
     private Node next = null;
-    private List<SourceSpan> sourceSpans = new ArrayList<>();
+    private List<SourceSpan> sourceSpans = null;
 
     public abstract void accept(Visitor visitor);
 
@@ -33,18 +38,6 @@ public abstract class Node {
 
     public Node getParent() {
         return parent;
-    }
-
-    public List<SourceSpan> getSourceSpans() {
-        return Collections.unmodifiableList(sourceSpans);
-    }
-
-    public void setSourceSpans(List<SourceSpan> sourceSpans) {
-        this.sourceSpans = new ArrayList<>(sourceSpans);
-    }
-
-    public void addSourceSpan(SourceSpan sourceSpan) {
-        this.sourceSpans.add(sourceSpan);
     }
 
     protected void setParent(Node parent) {
@@ -119,6 +112,35 @@ public abstract class Node {
         if (sibling.prev == null) {
             sibling.parent.firstChild = sibling;
         }
+    }
+
+
+    /**
+     * @return the source spans of this node if included by the parser, an empty list otherwise
+     */
+    public List<SourceSpan> getSourceSpans() {
+        return sourceSpans != null ? Collections.unmodifiableList(sourceSpans) : Collections.<SourceSpan>emptyList();
+    }
+
+    /**
+     * Replace the current source spans with the provided list.
+     *
+     * @param sourceSpans the new source spans to set
+     */
+    public void setSourceSpans(List<SourceSpan> sourceSpans) {
+        this.sourceSpans = new ArrayList<>(sourceSpans);
+    }
+
+    /**
+     * Add a source span to the end of the list.
+     *
+     * @param sourceSpan the source span to add
+     */
+    public void addSourceSpan(SourceSpan sourceSpan) {
+        if (sourceSpans == null) {
+            this.sourceSpans = new ArrayList<>();
+        }
+        this.sourceSpans.add(sourceSpan);
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -1,6 +1,7 @@
 package org.commonmark.node;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public abstract class Node {
@@ -35,11 +36,15 @@ public abstract class Node {
     }
 
     public List<SourceSpan> getSourceSpans() {
-        return sourceSpans;
+        return Collections.unmodifiableList(sourceSpans);
     }
 
     public void setSourceSpans(List<SourceSpan> sourceSpans) {
         this.sourceSpans = new ArrayList<>(sourceSpans);
+    }
+
+    public void addSourceSpan(SourceSpan sourceSpan) {
+        this.sourceSpans.add(sourceSpan);
     }
 
     protected void setParent(Node parent) {

--- a/commonmark/src/main/java/org/commonmark/node/Node.java
+++ b/commonmark/src/main/java/org/commonmark/node/Node.java
@@ -1,7 +1,6 @@
 package org.commonmark.node;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public abstract class Node {
@@ -36,7 +35,7 @@ public abstract class Node {
     }
 
     public List<SourceSpan> getSourceSpans() {
-        return Collections.unmodifiableList(sourceSpans);
+        return sourceSpans;
     }
 
     public void setSourceSpans(List<SourceSpan> sourceSpans) {

--- a/commonmark/src/main/java/org/commonmark/node/Paragraph.java
+++ b/commonmark/src/main/java/org/commonmark/node/Paragraph.java
@@ -1,5 +1,8 @@
 package org.commonmark.node;
 
+/**
+ * A paragraph block, contains inline nodes such as {@link Text}
+ */
 public class Paragraph extends Block {
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
+++ b/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
@@ -2,6 +2,25 @@ package org.commonmark.node;
 
 import java.util.Objects;
 
+/**
+ * A source span references a snippet of text from the source input.
+ * <p>
+ * It has a starting position (line and column index) and a length of how many characters it spans.
+ * <p>
+ * For example, this CommonMark source text:
+ * <pre><code>
+ * > foo
+ * </code></pre>
+ * The {@link BlockQuote} node would have this source span: line 0, column 0, length 5.
+ * <p>
+ * The {@link Paragraph} node inside it would have: line 0, column 2, length 3.
+ * <p>
+ * If a block has multiple lines, it will have a source span for each line.
+ * <p>
+ * Note that the column index and length are measured in Java characters (UTF-16 code units). If you're outputting them
+ * to be consumed by another programming language, e.g. one that uses UTF-8 strings, you will need to translate them,
+ * otherwise characters such as emojis will result in incorrect positions.
+ */
 public class SourceSpan {
 
     private final int lineIndex;
@@ -33,7 +52,7 @@ public class SourceSpan {
     }
 
     /**
-     * @return length of the span
+     * @return length of the span in characters
      */
     public int getLength() {
         return length;

--- a/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
+++ b/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
@@ -61,8 +61,8 @@ public class SourceSpan {
     @Override
     public String toString() {
         return "SourceSpan{" +
-                "lineIndex=" + lineIndex +
-                ", columnIndex=" + columnIndex +
+                "line=" + lineIndex +
+                ", column=" + columnIndex +
                 ", length=" + length +
                 "}";
     }

--- a/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
+++ b/commonmark/src/main/java/org/commonmark/node/SourceSpan.java
@@ -1,0 +1,69 @@
+package org.commonmark.node;
+
+import java.util.Objects;
+
+public class SourceSpan {
+
+    private final int lineIndex;
+    private final int columnIndex;
+    private final int length;
+
+    public static SourceSpan of(int lineIndex, int columnIndex, int length) {
+        return new SourceSpan(lineIndex, columnIndex, length);
+    }
+
+    private SourceSpan(int lineIndex, int columnIndex, int length) {
+        this.lineIndex = lineIndex;
+        this.columnIndex = columnIndex;
+        this.length = length;
+    }
+
+    /**
+     * @return 0-based index of line in source
+     */
+    public int getLineIndex() {
+        return lineIndex;
+    }
+
+    /**
+     * @return 0-based index of column (character on line) in source
+     */
+    public int getColumnIndex() {
+        return columnIndex;
+    }
+
+    /**
+     * @return length of the span
+     */
+    public int getLength() {
+        return length;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SourceSpan that = (SourceSpan) o;
+        return lineIndex == that.lineIndex &&
+                columnIndex == that.columnIndex &&
+                length == that.length;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lineIndex, columnIndex, length);
+    }
+
+    @Override
+    public String toString() {
+        return "SourceSpan{" +
+                "lineIndex=" + lineIndex +
+                ", columnIndex=" + columnIndex +
+                ", length=" + length +
+                "}";
+    }
+}

--- a/commonmark/src/main/java/org/commonmark/parser/IncludeSourceSpans.java
+++ b/commonmark/src/main/java/org/commonmark/parser/IncludeSourceSpans.java
@@ -1,0 +1,16 @@
+package org.commonmark.parser;
+
+/**
+ * Whether to include {@link org.commonmark.node.SourceSpan} or not while parsing,
+ * see {@link Parser.Builder#includeSourceSpans(IncludeSourceSpans)}.
+ */
+public enum IncludeSourceSpans {
+    /**
+     * Do not include source spans.
+     */
+    NONE,
+    /**
+     * Include source spans on {@link org.commonmark.node.Block} nodes.
+     */
+    BLOCKS,
+}

--- a/commonmark/src/main/java/org/commonmark/parser/Parser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/Parser.java
@@ -4,7 +4,16 @@ import org.commonmark.Extension;
 import org.commonmark.internal.DocumentParser;
 import org.commonmark.internal.InlineParserContextImpl;
 import org.commonmark.internal.InlineParserImpl;
-import org.commonmark.node.*;
+import org.commonmark.node.Block;
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.Heading;
+import org.commonmark.node.HtmlBlock;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.LinkReferenceDefinition;
+import org.commonmark.node.ListBlock;
+import org.commonmark.node.Node;
+import org.commonmark.node.ThematicBreak;
 import org.commonmark.parser.block.BlockParserFactory;
 import org.commonmark.parser.delimiter.DelimiterProcessor;
 
@@ -31,12 +40,14 @@ public class Parser {
     private final List<DelimiterProcessor> delimiterProcessors;
     private final InlineParserFactory inlineParserFactory;
     private final List<PostProcessor> postProcessors;
+    private final IncludeSourceSpans includeSourceSpans;
 
     private Parser(Builder builder) {
         this.blockParserFactories = DocumentParser.calculateBlockParserFactories(builder.blockParserFactories, builder.enabledBlockTypes);
         this.inlineParserFactory = builder.getInlineParserFactory();
         this.postProcessors = builder.postProcessors;
         this.delimiterProcessors = builder.delimiterProcessors;
+        this.includeSourceSpans = builder.includeSourceSpans;
 
         // Try to construct an inline parser. Invalid configuration might result in an exception, which we want to
         // detect as soon as possible.
@@ -99,7 +110,7 @@ public class Parser {
     }
 
     private DocumentParser createDocumentParser() {
-        return new DocumentParser(blockParserFactories, inlineParserFactory, delimiterProcessors);
+        return new DocumentParser(blockParserFactories, inlineParserFactory, delimiterProcessors, includeSourceSpans);
     }
 
     private Node postProcess(Node document) {
@@ -118,6 +129,7 @@ public class Parser {
         private final List<PostProcessor> postProcessors = new ArrayList<>();
         private Set<Class<? extends Block>> enabledBlockTypes = DocumentParser.getDefaultBlockParserTypes();
         private InlineParserFactory inlineParserFactory;
+        private IncludeSourceSpans includeSourceSpans = IncludeSourceSpans.NONE;
 
         /**
          * @return the configured {@link Parser}
@@ -167,7 +179,7 @@ public class Parser {
          * </pre>
          *
          * @param enabledBlockTypes A list of block nodes the parser will parse.
-         * If this list is empty, the parser will not recognize any CommonMark core features.
+         *                          If this list is empty, the parser will not recognize any CommonMark core features.
          * @return {@code this}
          */
         public Builder enabledBlockTypes(Set<Class<? extends Block>> enabledBlockTypes) {
@@ -175,6 +187,19 @@ public class Parser {
                 throw new NullPointerException("enabledBlockTypes must not be null");
             }
             this.enabledBlockTypes = enabledBlockTypes;
+            return this;
+        }
+
+        /**
+         * Whether to calculate {@link org.commonmark.node.SourceSpan} for {@link Node}.
+         * <p>
+         * By default, source spans are disabled.
+         *
+         * @param includeSourceSpans which kind of source spans should be included
+         * @return {@code this}
+         */
+        public Builder includeSourceSpans(IncludeSourceSpans includeSourceSpans) {
+            this.includeSourceSpans = includeSourceSpans;
             return this;
         }
 

--- a/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParser.java
@@ -27,7 +27,7 @@ public abstract class AbstractBlockParser implements BlockParser {
 
     @Override
     public void addSourceSpan(SourceSpan sourceSpan) {
-        getBlock().getSourceSpans().add(sourceSpan);
+        getBlock().addSourceSpan(sourceSpan);
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/AbstractBlockParser.java
@@ -1,6 +1,7 @@
 package org.commonmark.parser.block;
 
 import org.commonmark.node.Block;
+import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.InlineParser;
 
 public abstract class AbstractBlockParser implements BlockParser {
@@ -22,6 +23,11 @@ public abstract class AbstractBlockParser implements BlockParser {
 
     @Override
     public void addLine(CharSequence line) {
+    }
+
+    @Override
+    public void addSourceSpan(SourceSpan sourceSpan) {
+        getBlock().getSourceSpans().add(sourceSpan);
     }
 
     @Override

--- a/commonmark/src/main/java/org/commonmark/parser/block/BlockParser.java
+++ b/commonmark/src/main/java/org/commonmark/parser/block/BlockParser.java
@@ -1,6 +1,7 @@
 package org.commonmark.parser.block;
 
 import org.commonmark.node.Block;
+import org.commonmark.node.SourceSpan;
 import org.commonmark.parser.InlineParser;
 
 /**
@@ -33,6 +34,13 @@ public interface BlockParser {
     BlockContinue tryContinue(ParserState parserState);
 
     void addLine(CharSequence line);
+
+    /**
+     * Add a source span of the currently parsed block. The default implementation in {@link AbstractBlockParser} adds
+     * it to the block. Unless you have some complicated parsing where you need to check source positions, you don't
+     * need to override this.
+     */
+    void addSourceSpan(SourceSpan sourceSpan);
 
     void closeBlock();
 

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpanRenderer.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpanRenderer.java
@@ -1,0 +1,92 @@
+package org.commonmark.test;
+
+import org.commonmark.node.AbstractVisitor;
+import org.commonmark.node.Node;
+import org.commonmark.node.SourceSpan;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class SourceSpanRenderer {
+
+    public static String render(Node document, String source) {
+        SourceSpanMarkersVisitor visitor = new SourceSpanMarkersVisitor();
+        document.accept(visitor);
+        Map<Integer, Map<Integer, List<String>>> markers = visitor.getMarkers();
+
+        StringBuilder sb = new StringBuilder();
+
+        String[] lines = source.split("\n");
+
+        for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+            String line = lines[lineIndex];
+            Map<Integer, List<String>> lineMarkers = markers.get(lineIndex);
+            for (int i = 0; i < line.length(); i++) {
+                appendMarkers(lineMarkers, i, sb);
+                sb.append(line.charAt(i));
+            }
+            appendMarkers(lineMarkers, line.length(), sb);
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    private static void appendMarkers(Map<Integer, List<String>> lineMarkers, int columnIndex, StringBuilder sb) {
+        if (lineMarkers != null) {
+            List<String> columnMarkers = lineMarkers.get(columnIndex);
+            if (columnMarkers != null) {
+                for (String marker : columnMarkers) {
+                    sb.append(marker);
+                }
+            }
+        }
+    }
+
+    private static class SourceSpanMarkersVisitor extends AbstractVisitor {
+
+        private final Map<Integer, Map<Integer, List<String>>> markers = new HashMap<>();
+        private final String opening = "({[<⸢⸤";
+        private final String closing = ")}]>⸣⸥";
+
+        private int markerIndex;
+
+        public Map<Integer, Map<Integer, List<String>>> getMarkers() {
+            return markers;
+        }
+
+        @Override
+        protected void visitChildren(Node parent) {
+            if (!parent.getSourceSpans().isEmpty()) {
+                for (SourceSpan sourceSpan : parent.getSourceSpans()) {
+                    String opener = String.valueOf(opening.charAt(markerIndex % opening.length()));
+                    String closer = String.valueOf(closing.charAt(markerIndex % closing.length()));
+
+                    int col = sourceSpan.getColumnIndex();
+                    getMarkers(sourceSpan.getLineIndex(), col).add(opener);
+                    getMarkers(sourceSpan.getLineIndex(), col + sourceSpan.getLength()).add(0, closer);
+                }
+                markerIndex++;
+            }
+            super.visitChildren(parent);
+        }
+
+        private List<String> getMarkers(int lineIndex, int columnIndex) {
+            Map<Integer, List<String>> columnMap = markers.get(lineIndex);
+            if (columnMap == null) {
+                columnMap = new HashMap<>();
+                markers.put(lineIndex, columnMap);
+            }
+
+            List<String> markers = columnMap.get(columnIndex);
+            if (markers == null) {
+                markers = new LinkedList<>();
+                columnMap.put(columnIndex, markers);
+            }
+
+            return markers;
+        }
+    }
+}

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpanRenderer.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpanRenderer.java
@@ -47,9 +47,10 @@ public class SourceSpanRenderer {
 
     private static class SourceSpanMarkersVisitor extends AbstractVisitor {
 
+        private static final String OPENING = "({[<⸢⸤";
+        private static final String CLOSING = ")}]>⸣⸥";
+
         private final Map<Integer, Map<Integer, List<String>>> markers = new HashMap<>();
-        private final String opening = "({[<⸢⸤";
-        private final String closing = ")}]>⸣⸥";
 
         private int markerIndex;
 
@@ -61,8 +62,8 @@ public class SourceSpanRenderer {
         protected void visitChildren(Node parent) {
             if (!parent.getSourceSpans().isEmpty()) {
                 for (SourceSpan sourceSpan : parent.getSourceSpans()) {
-                    String opener = String.valueOf(opening.charAt(markerIndex % opening.length()));
-                    String closer = String.valueOf(closing.charAt(markerIndex % closing.length()));
+                    String opener = String.valueOf(OPENING.charAt(markerIndex % OPENING.length()));
+                    String closer = String.valueOf(CLOSING.charAt(markerIndex % CLOSING.length()));
 
                     int col = sourceSpan.getColumnIndex();
                     getMarkers(sourceSpan.getLineIndex(), col).add(opener);

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -14,12 +14,18 @@ import org.commonmark.node.ThematicBreak;
 import org.commonmark.parser.Parser;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.*;
 
 public class SourceSpansTest {
 
     private static final Parser PARSER = Parser.builder().build();
+
+    // TODO: Tests for when column is within tab
+
+    // TODO: Tests for where paragraph starts with link reference definitions
 
     @Test
     public void paragraph() {
@@ -172,7 +178,7 @@ public class SourceSpansTest {
         if (node == null) {
             fail("Expected to find " + nodeClass + " node");
         } else {
-            assertThat(node.getSourceSpans(), contains(expectedSourceSpans));
+            assertEquals(Arrays.asList(expectedSourceSpans), node.getSourceSpans());
         }
     }
 }

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -12,14 +12,14 @@ import org.commonmark.node.Node;
 import org.commonmark.node.Paragraph;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.node.ThematicBreak;
-import org.commonmark.parser.Parser;
 import org.commonmark.parser.IncludeSourceSpans;
+import org.commonmark.parser.Parser;
 import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class SourceSpansTest {
 
@@ -99,7 +99,7 @@ public class SourceSpansTest {
 
         Node document = PARSER.parse("```\nfoo\n```\nbar\n");
         Paragraph paragraph = (Paragraph) document.getLastChild();
-        assertThat(paragraph.getSourceSpans(), contains(SourceSpan.of(3, 0, 3)));
+        assertEquals(Arrays.asList(SourceSpan.of(3, 0, 3)), paragraph.getSourceSpans());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SourceSpansTest {
 
         Node document = PARSER.parse("* foo\n  * bar\n");
         ListBlock listBlock = (ListBlock) document.getFirstChild().getFirstChild().getLastChild();
-        assertThat(listBlock.getSourceSpans(), contains(SourceSpan.of(1, 2, 5)));
+        assertEquals(Arrays.asList(SourceSpan.of(1, 2, 5)), listBlock.getSourceSpans());
     }
 
     @Test

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -5,6 +5,7 @@ import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.node.Heading;
 import org.commonmark.node.HtmlBlock;
 import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.LinkReferenceDefinition;
 import org.commonmark.node.ListBlock;
 import org.commonmark.node.ListItem;
 import org.commonmark.node.Node;
@@ -23,15 +24,11 @@ public class SourceSpansTest {
 
     private static final Parser PARSER = Parser.builder().build();
 
-    // TODO: Tests for when column is within tab
-
-    // TODO: Tests for where paragraph starts with link reference definitions
-
     @Test
     public void paragraph() {
         assertSpans("foo\n", Paragraph.class, SourceSpan.of(0, 0, 3));
         assertSpans("foo\nbar\n", Paragraph.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3));
-        assertSpans("  foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+        assertSpans("  foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
         assertSpans("> foo\n> bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
         assertSpans("* foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
         assertSpans("* foo\nbar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 0, 3));
@@ -40,14 +37,14 @@ public class SourceSpansTest {
     @Test
     public void thematicBreak() {
         assertSpans("---\n", ThematicBreak.class, SourceSpan.of(0, 0, 3));
-        assertSpans("  ---\n", ThematicBreak.class, SourceSpan.of(0, 2, 3));
+        assertSpans("  ---\n", ThematicBreak.class, SourceSpan.of(0, 0, 5));
         assertSpans("> ---\n", ThematicBreak.class, SourceSpan.of(0, 2, 3));
     }
 
     @Test
     public void atxHeading() {
         assertSpans("# foo", Heading.class, SourceSpan.of(0, 0, 5));
-        assertSpans(" # foo", Heading.class, SourceSpan.of(0, 1, 5));
+        assertSpans(" # foo", Heading.class, SourceSpan.of(0, 0, 6));
         assertSpans("## foo ##", Heading.class, SourceSpan.of(0, 0, 9));
         assertSpans("> # foo", Heading.class, SourceSpan.of(0, 2, 5));
     }
@@ -56,40 +53,42 @@ public class SourceSpansTest {
     public void setextHeading() {
         assertSpans("foo\n===\n", Heading.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3));
         assertSpans("foo\nbar\n====\n", Heading.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 4));
-        assertSpans("  foo\n  ===\n", Heading.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+        assertSpans("  foo\n  ===\n", Heading.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
         assertSpans("> foo\n> ===\n", Heading.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
     }
 
     @Test
     public void indentedCodeBlock() {
-        assertSpans("    foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3));
-        assertSpans("     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 4));
-        assertSpans("\tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 1, 3));
-        assertSpans(" \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 2, 3));
-        assertSpans("  \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 3, 3));
-        assertSpans("   \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3));
-        assertSpans("    \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 4));
-        assertSpans("    \t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 5));
-        assertSpans("\t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 1, 4));
-        assertSpans("\t  foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 1, 5));
-        assertSpans("    foo\n     bar\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3), SourceSpan.of(1, 4, 4));
-        assertSpans("    foo\n\tbar\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3), SourceSpan.of(1, 1, 3));
-        assertSpans("    foo\n    \n     \n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3), SourceSpan.of(2, 4, 1));
-        assertSpans(">     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 6, 3));
+        assertSpans("    foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7));
+        assertSpans("     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 8));
+        assertSpans("\tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 4));
+        assertSpans(" \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 5));
+        assertSpans("  \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 6));
+        assertSpans("   \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7));
+        assertSpans("    \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 8));
+        assertSpans("    \t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 9));
+        assertSpans("\t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 5));
+        assertSpans("\t  foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 6));
+        assertSpans("    foo\n     bar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 8));
+        assertSpans("    foo\n\tbar\n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 4));
+        assertSpans("    foo\n    \n     \n", IndentedCodeBlock.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 5));
+        assertSpans(">     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 2, 7));
     }
 
     @Test
     public void fencedCodeBlock() {
         assertSpans("```\nfoo\n```\n", FencedCodeBlock.class,
                 SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+        assertSpans("```\n foo\n```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 3));
         assertSpans("```\nfoo\nbar\n```\n", FencedCodeBlock.class,
                 SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
         assertSpans("```\nfoo\nbar\n```\n", FencedCodeBlock.class,
                 SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
         assertSpans("   ```\n   foo\n   ```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 3, 3), SourceSpan.of(1, 3, 3), SourceSpan.of(2, 3, 3));
+                SourceSpan.of(0, 0, 6), SourceSpan.of(1, 0, 6), SourceSpan.of(2, 0, 6));
         assertSpans(" ```\n foo\nfoo\n```\n", FencedCodeBlock.class,
-                SourceSpan.of(0, 1, 3), SourceSpan.of(1, 1, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
+                SourceSpan.of(0, 0, 4), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
         assertSpans("```info\nfoo\n```\n", FencedCodeBlock.class,
                 SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
         assertSpans("* ```\n  foo\n  ```\n", FencedCodeBlock.class,
@@ -105,7 +104,10 @@ public class SourceSpansTest {
     @Test
     public void htmlBlock() {
         assertSpans("<div>\n", HtmlBlock.class, SourceSpan.of(0, 0, 5));
-        assertSpans(" <div>\n foo\n </div>\n", HtmlBlock.class, SourceSpan.of(0, 0, 6), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 7));
+        assertSpans(" <div>\n foo\n </div>\n", HtmlBlock.class,
+                SourceSpan.of(0, 0, 6),
+                SourceSpan.of(1, 0, 4),
+                SourceSpan.of(2, 0, 7));
         assertSpans("* <div>\n", HtmlBlock.class, SourceSpan.of(0, 2, 5));
     }
 
@@ -114,8 +116,8 @@ public class SourceSpansTest {
         assertSpans(">foo\n", BlockQuote.class, SourceSpan.of(0, 0, 4));
         assertSpans("> foo\n", BlockQuote.class, SourceSpan.of(0, 0, 5));
         assertSpans(">  foo\n", BlockQuote.class, SourceSpan.of(0, 0, 6));
-        assertSpans(" > foo\n", BlockQuote.class, SourceSpan.of(0, 1, 5));
-        assertSpans("   > foo\n  > bar\n", BlockQuote.class, SourceSpan.of(0, 3, 5), SourceSpan.of(1, 2, 5));
+        assertSpans(" > foo\n", BlockQuote.class, SourceSpan.of(0, 0, 6));
+        assertSpans("   > foo\n  > bar\n", BlockQuote.class, SourceSpan.of(0, 0, 8), SourceSpan.of(1, 0, 7));
         // Lazy continuations
         assertSpans("> foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3));
         assertSpans("> foo\nbar\n> baz\n", BlockQuote.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 5));
@@ -125,17 +127,17 @@ public class SourceSpansTest {
     @Test
     public void listBlock() {
         assertSpans("* foo\n", ListBlock.class, SourceSpan.of(0, 0, 5));
-        assertSpans("* foo\n  bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 3));
+        assertSpans("* foo\n  bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
         assertSpans("* foo\n* bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
-        assertSpans("* foo\n  # bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 5));
-        assertSpans("* foo\n  * bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 5));
+        assertSpans("* foo\n  # bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 7));
+        assertSpans("* foo\n  * bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 7));
         assertSpans("* foo\n> bar\n", ListBlock.class, SourceSpan.of(0, 0, 5));
         assertSpans("> * foo\n", ListBlock.class, SourceSpan.of(0, 2, 5));
 
         // Lazy continuations
         assertSpans("* foo\nbar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
         assertSpans("* foo\nbar\n* baz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 5));
-        assertSpans("* foo\n  * bar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 5), SourceSpan.of(2, 0, 3));
+        assertSpans("* foo\n  * bar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 7), SourceSpan.of(2, 0, 3));
 
         Node document = PARSER.parse("* foo\n  * bar\n");
         ListBlock listBlock = (ListBlock) document.getFirstChild().getFirstChild().getLastChild();
@@ -145,11 +147,11 @@ public class SourceSpansTest {
     @Test
     public void listItem() {
         assertSpans("* foo\n", ListItem.class, SourceSpan.of(0, 0, 5));
-        assertSpans(" * foo\n", ListItem.class, SourceSpan.of(0, 1, 5));
-        assertSpans("  * foo\n", ListItem.class, SourceSpan.of(0, 2, 5));
-        assertSpans("   * foo\n", ListItem.class, SourceSpan.of(0, 3, 5));
-        assertSpans("*\n  foo\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 2, 3));
-        assertSpans("*\n  foo\n  bar\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 2, 3), SourceSpan.of(2, 2, 3));
+        assertSpans(" * foo\n", ListItem.class, SourceSpan.of(0, 0, 6));
+        assertSpans("  * foo\n", ListItem.class, SourceSpan.of(0, 0, 7));
+        assertSpans("   * foo\n", ListItem.class, SourceSpan.of(0, 0, 8));
+        assertSpans("*\n  foo\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 0, 5));
+        assertSpans("*\n  foo\n  bar\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 0, 5), SourceSpan.of(2, 0, 5));
         assertSpans("> * foo\n", ListItem.class, SourceSpan.of(0, 2, 5));
 
         // Lazy continuations
@@ -158,10 +160,36 @@ public class SourceSpansTest {
     }
 
     @Test
+    public void linkReferenceDefinition() {
+        // This is tricky due to how link reference definition parsing works. It is stripped from the paragraph if it's
+        // successfully parsed, otherwise it stays part of the paragraph.
+        Node document = PARSER.parse("[foo]: /url\ntext\n");
+
+        LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
+        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
+
+        Paragraph paragraph = (Paragraph) document.getLastChild();
+        assertEquals(Arrays.asList(SourceSpan.of(1, 0, 4)), paragraph.getSourceSpans());
+    }
+
+    @Test
+    public void linkReferenceDefinitionHeading() {
+        // This is probably the trickiest because we have a link reference definition at the start of a paragraph
+        // that gets replaced because of a heading. Phew.
+        Node document = PARSER.parse("[foo]: /url\nHeading\n===\n");
+
+        LinkReferenceDefinition linkReferenceDefinition = (LinkReferenceDefinition) document.getFirstChild();
+        assertEquals(Arrays.asList(SourceSpan.of(0, 0, 11)), linkReferenceDefinition.getSourceSpans());
+
+        Heading heading = (Heading) document.getLastChild();
+        assertEquals(Arrays.asList(SourceSpan.of(1, 0, 7), SourceSpan.of(2, 0, 3)), heading.getSourceSpans());
+    }
+
+    @Test
     public void visualCheck() {
-        assertEquals("(> {[* <foo>]})\n(>   {[<bar>]})\n(> {⸢* ⸤baz⸥⸣})\n",
+        assertEquals("(> {[* <foo>]})\n(> {[  <bar>]})\n(> {⸢* ⸤baz⸥⸣})\n",
                 visualizeSourceSpans("> * foo\n>   bar\n> * baz\n"));
-        assertEquals("(> {[* <```>]})\n(>   {[<foo>]})\n(>   {[<```>]})\n",
+        assertEquals("(> {[* <```>]})\n(> {[  <foo>]})\n(> {[  <```>]})\n",
                 visualizeSourceSpans("> * ```\n>   foo\n>   ```"));
     }
 

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -13,6 +13,7 @@ import org.commonmark.node.Paragraph;
 import org.commonmark.node.SourceSpan;
 import org.commonmark.node.ThematicBreak;
 import org.commonmark.parser.Parser;
+import org.commonmark.parser.IncludeSourceSpans;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -22,7 +23,7 @@ import static org.junit.Assert.*;
 
 public class SourceSpansTest {
 
-    private static final Parser PARSER = Parser.builder().build();
+    private static final Parser PARSER = Parser.builder().includeSourceSpans(IncludeSourceSpans.BLOCKS).build();
 
     @Test
     public void paragraph() {

--- a/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
+++ b/commonmark/src/test/java/org/commonmark/test/SourceSpansTest.java
@@ -1,0 +1,178 @@
+package org.commonmark.test;
+
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.Heading;
+import org.commonmark.node.HtmlBlock;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.ListBlock;
+import org.commonmark.node.ListItem;
+import org.commonmark.node.Node;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.SourceSpan;
+import org.commonmark.node.ThematicBreak;
+import org.commonmark.parser.Parser;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.*;
+
+public class SourceSpansTest {
+
+    private static final Parser PARSER = Parser.builder().build();
+
+    @Test
+    public void paragraph() {
+        assertSpans("foo\n", Paragraph.class, SourceSpan.of(0, 0, 3));
+        assertSpans("foo\nbar\n", Paragraph.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3));
+        assertSpans("  foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+        assertSpans("> foo\n> bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+        assertSpans("* foo\n  bar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+        assertSpans("* foo\nbar\n", Paragraph.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 0, 3));
+    }
+
+    @Test
+    public void thematicBreak() {
+        assertSpans("---\n", ThematicBreak.class, SourceSpan.of(0, 0, 3));
+        assertSpans("  ---\n", ThematicBreak.class, SourceSpan.of(0, 2, 3));
+        assertSpans("> ---\n", ThematicBreak.class, SourceSpan.of(0, 2, 3));
+    }
+
+    @Test
+    public void atxHeading() {
+        assertSpans("# foo", Heading.class, SourceSpan.of(0, 0, 5));
+        assertSpans(" # foo", Heading.class, SourceSpan.of(0, 1, 5));
+        assertSpans("## foo ##", Heading.class, SourceSpan.of(0, 0, 9));
+        assertSpans("> # foo", Heading.class, SourceSpan.of(0, 2, 5));
+    }
+
+    @Test
+    public void setextHeading() {
+        assertSpans("foo\n===\n", Heading.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3));
+        assertSpans("foo\nbar\n====\n", Heading.class, SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 4));
+        assertSpans("  foo\n  ===\n", Heading.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+        assertSpans("> foo\n> ===\n", Heading.class, SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3));
+    }
+
+    @Test
+    public void indentedCodeBlock() {
+        assertSpans("    foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3));
+        assertSpans("     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 4));
+        assertSpans("\tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 1, 3));
+        assertSpans(" \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 2, 3));
+        assertSpans("  \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 3, 3));
+        assertSpans("   \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3));
+        assertSpans("    \tfoo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 4));
+        assertSpans("    \t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 5));
+        assertSpans("\t foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 1, 4));
+        assertSpans("\t  foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 1, 5));
+        assertSpans("    foo\n     bar\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3), SourceSpan.of(1, 4, 4));
+        assertSpans("    foo\n\tbar\n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3), SourceSpan.of(1, 1, 3));
+        assertSpans("    foo\n    \n     \n", IndentedCodeBlock.class, SourceSpan.of(0, 4, 3), SourceSpan.of(2, 4, 1));
+        assertSpans(">     foo\n", IndentedCodeBlock.class, SourceSpan.of(0, 6, 3));
+    }
+
+    @Test
+    public void fencedCodeBlock() {
+        assertSpans("```\nfoo\n```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+        assertSpans("```\nfoo\nbar\n```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
+        assertSpans("```\nfoo\nbar\n```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 3), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
+        assertSpans("   ```\n   foo\n   ```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 3, 3), SourceSpan.of(1, 3, 3), SourceSpan.of(2, 3, 3));
+        assertSpans(" ```\n foo\nfoo\n```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 1, 3), SourceSpan.of(1, 1, 3), SourceSpan.of(2, 0, 3), SourceSpan.of(3, 0, 3));
+        assertSpans("```info\nfoo\n```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+        assertSpans("* ```\n  foo\n  ```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3), SourceSpan.of(2, 2, 3));
+        assertSpans("> ```\n> foo\n> ```\n", FencedCodeBlock.class,
+                SourceSpan.of(0, 2, 3), SourceSpan.of(1, 2, 3), SourceSpan.of(2, 2, 3));
+
+        Node document = PARSER.parse("```\nfoo\n```\nbar\n");
+        Paragraph paragraph = (Paragraph) document.getLastChild();
+        assertThat(paragraph.getSourceSpans(), contains(SourceSpan.of(3, 0, 3)));
+    }
+
+    @Test
+    public void htmlBlock() {
+        assertSpans("<div>\n", HtmlBlock.class, SourceSpan.of(0, 0, 5));
+        assertSpans(" <div>\n foo\n </div>\n", HtmlBlock.class, SourceSpan.of(0, 0, 6), SourceSpan.of(1, 0, 4), SourceSpan.of(2, 0, 7));
+        assertSpans("* <div>\n", HtmlBlock.class, SourceSpan.of(0, 2, 5));
+    }
+
+    @Test
+    public void blockQuote() {
+        assertSpans(">foo\n", BlockQuote.class, SourceSpan.of(0, 0, 4));
+        assertSpans("> foo\n", BlockQuote.class, SourceSpan.of(0, 0, 5));
+        assertSpans(">  foo\n", BlockQuote.class, SourceSpan.of(0, 0, 6));
+        assertSpans(" > foo\n", BlockQuote.class, SourceSpan.of(0, 1, 5));
+        assertSpans("   > foo\n  > bar\n", BlockQuote.class, SourceSpan.of(0, 3, 5), SourceSpan.of(1, 2, 5));
+        // Lazy continuations
+        assertSpans("> foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3));
+        assertSpans("> foo\nbar\n> baz\n", BlockQuote.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 5));
+        assertSpans("> > foo\nbar\n", BlockQuote.class, SourceSpan.of(0, 0, 7), SourceSpan.of(1, 0, 3));
+    }
+
+    @Test
+    public void listBlock() {
+        assertSpans("* foo\n", ListBlock.class, SourceSpan.of(0, 0, 5));
+        assertSpans("* foo\n  bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 3));
+        assertSpans("* foo\n* bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 5));
+        assertSpans("* foo\n  # bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 5));
+        assertSpans("* foo\n  * bar\n", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 5));
+        assertSpans("* foo\n> bar\n", ListBlock.class, SourceSpan.of(0, 0, 5));
+        assertSpans("> * foo\n", ListBlock.class, SourceSpan.of(0, 2, 5));
+
+        // Lazy continuations
+        assertSpans("* foo\nbar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+        assertSpans("* foo\nbar\n* baz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 5));
+        assertSpans("* foo\n  * bar\nbaz", ListBlock.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 2, 5), SourceSpan.of(2, 0, 3));
+
+        Node document = PARSER.parse("* foo\n  * bar\n");
+        ListBlock listBlock = (ListBlock) document.getFirstChild().getFirstChild().getLastChild();
+        assertThat(listBlock.getSourceSpans(), contains(SourceSpan.of(1, 2, 5)));
+    }
+
+    @Test
+    public void listItem() {
+        assertSpans("* foo\n", ListItem.class, SourceSpan.of(0, 0, 5));
+        assertSpans(" * foo\n", ListItem.class, SourceSpan.of(0, 1, 5));
+        assertSpans("  * foo\n", ListItem.class, SourceSpan.of(0, 2, 5));
+        assertSpans("   * foo\n", ListItem.class, SourceSpan.of(0, 3, 5));
+        assertSpans("*\n  foo\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 2, 3));
+        assertSpans("*\n  foo\n  bar\n", ListItem.class, SourceSpan.of(0, 0, 1), SourceSpan.of(1, 2, 3), SourceSpan.of(2, 2, 3));
+        assertSpans("> * foo\n", ListItem.class, SourceSpan.of(0, 2, 5));
+
+        // Lazy continuations
+        assertSpans("* foo\nbar\n", ListItem.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3));
+        assertSpans("* foo\nbar\nbaz\n", ListItem.class, SourceSpan.of(0, 0, 5), SourceSpan.of(1, 0, 3), SourceSpan.of(2, 0, 3));
+    }
+
+    @Test
+    public void visualCheck() {
+        assertEquals("(> {[* <foo>]})\n(>   {[<bar>]})\n(> {⸢* ⸤baz⸥⸣})\n",
+                visualizeSourceSpans("> * foo\n>   bar\n> * baz\n"));
+        assertEquals("(> {[* <```>]})\n(>   {[<foo>]})\n(>   {[<```>]})\n",
+                visualizeSourceSpans("> * ```\n>   foo\n>   ```"));
+    }
+
+    private String visualizeSourceSpans(String source) {
+        Node document = PARSER.parse(source);
+        return SourceSpanRenderer.render(document, source);
+    }
+
+    private static void assertSpans(String input, Class<? extends Node> nodeClass, SourceSpan... expectedSourceSpans) {
+        Node node = PARSER.parse(input);
+        while (node != null && !nodeClass.isInstance(node)) {
+            node = node.getFirstChild();
+        }
+        if (node == null) {
+            fail("Expected to find " + nodeClass + " node");
+        } else {
+            assertThat(node.getSourceSpans(), contains(expectedSourceSpans));
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -144,11 +144,6 @@
                 <version>4.12</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
-            </dependency>
-            <dependency>
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
                 <version>1.17.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,11 @@
                 <version>4.12</version>
             </dependency>
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>1.3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
                 <version>1.17.5</version>


### PR DESCRIPTION
- Answer for "Where in the source input (line/column position and length) does this block come from?"
- Useful for things like editors that want to keep the input and rendered output scrolled to the same lines,
  or start editing on the block that was selected.
- Use `includeSourceSpans` on `Parser.Builder` to enable, read data with `Node.getSourceSpans`

Fixes #1 for block nodes. Will look into inline nodes too after #180, which might require more API changes.